### PR TITLE
Update tests for windows

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,5 +34,6 @@ def pytest_generate_tests(metafunc):
     if 'start_method' in metafunc.fixturenames:
         from multiprocessing import get_all_start_methods
         methods = get_all_start_methods()
-        methods.remove('fork')
+        if 'fork' in methods:  # fork not available on windows, so check before removing
+            methods.remove('fork')
         metafunc.parametrize("start_method", methods, scope='module')

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -45,13 +45,15 @@ async def hi():
 
 
 async def say_hello(other_actor):
-    await trio.sleep(0.4)  # wait for other actor to spawn
+    await trio.sleep(1)  # wait for other actor to spawn
     async with tractor.find_actor(other_actor) as portal:
+        assert portal is not None
         return await portal.run(__name__, 'hi')
 
 
 async def say_hello_use_wait(other_actor):
     async with tractor.wait_for_actor(other_actor) as portal:
+        assert portal is not None
         result = await portal.run(__name__, 'hi')
         return result
 

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -24,16 +24,17 @@ def try_set_start_method(name: str) -> mp.context.BaseContext:
     global _ctx
 
     allowed = mp.get_all_start_methods()
-    assert name in allowed
 
     if name not in allowed:
-        name == 'spawn'
+        name = 'spawn'
     elif name == 'fork':
         raise ValueError(
             "`fork` is unsupported due to incompatibility with `trio`"
         )
     elif name == 'forkserver':
         _forkserver_hackzorz.override_stdlib()
+
+    assert name in allowed
 
     _ctx = mp.get_context(name)
     return _ctx


### PR DESCRIPTION
This PR is to get the testsuite passing on windows.

Current failures occur on `test_streaming`. I've noticed that the process finishes in less time than `delay` [here](https://github.com/tgoodlet/tractor/blob/c0276c85dfa4688d76ca649e7edb8db89170dcbe/tests/test_streaming.py#L191 ) and [here](https://github.com/tgoodlet/tractor/blob/c0276c85dfa4688d76ca649e7edb8db89170dcbe/tests/test_streaming.py#L169), sometimes it's like half a second faster.

Since it looks like hardware related, probably that could be addressed on a different PR?


<details>
    <summary>Full log of tests here:</summary>
    
```log
(tractor_test19031001) B:\write\code\git\tractor>python -m pytest "tests/"
===================================================================================== test session starts =====================================================================================
platform win32 -- Python 3.7.2, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
rootdir: B:\write\code\git\tractor, inifile:
plugins: trio-0.5.2
collected 42 items

tests\test_cancellation.py .......                                                                                                                                                                                     [ 16%]
tests\test_discovery.py ...                                                                                                                                                                                            [ 23%]
tests\test_local.py .....                                                                                                                                                                                              [ 35%]
tests\test_multi_program.py ...                                                                                                                                                                                        [ 42%]
tests\test_pubsub.py ........                                                                                                                                                                                          [ 61%]
tests\test_rpc.py .....                                                                                                                                                                                                [ 73%]
tests\test_spawning.py ...                                                                                                                                                                                             [ 80%]
tests\test_streaming.py .FFFFFFF                                                                                                                                                                                       [100%]

========================================================================================================= FAILURES ==========================================================================================================
_________________________________________________________________________________________________ test_a_quadruple_example __________________________________________________________________________________________________

time_quad_ex = ([0, 1, 2, 3, 4, 5, ...], 3.8593993186950684)

    def test_a_quadruple_example(time_quad_ex):
        """This also serves as a kind of "we'd like to be this fast test"."""
        results, diff = time_quad_ex
        assert results
>       assert diff < 2.5
E       assert 3.8593993186950684 < 2.5

tests\test_streaming.py:179: AssertionError
--------------------------------------------------------------------------------------------------- Captured stdout setup ---------------------------------------------------------------------------------------------------
FINISHED ITERATING ('streamer_1', '1303ccd8-42eb-11e9-b71a-605718da7748')
FINISHED ITERATING ('streamer_2', '1342f952-42eb-11e9-b62d-605718da7748')
FINISHED ITERATING in aggregator
WAITING on `ActorNursery` to finish
AGGREGATOR COMPLETE!
STREAM TIME = 1.798220157623291
STREAM + SPAWN TIME = 2.3278956413269043
--------------------------------------------------------------------------------------------------- Captured stderr setup ---------------------------------------------------------------------------------------------------
Cancelling all streams with ('streamer_1', '1303ccd8-42eb-11e9-b71a-605718da7748')
Cancelling stream 1382e7ba-42eb-11e9-bb8a-605718da7748 to ('streamer_1', '1303ccd8-42eb-11e9-b71a-605718da7748')
Cancelling all streams with ('streamer_2', '1342f952-42eb-11e9-b62d-605718da7748')
Cancelling stream 1382e7bb-42eb-11e9-851d-605718da7748 to ('streamer_2', '1342f952-42eb-11e9-b62d-605718da7748')
1382e7ba-42eb-11e9-bb8a-605718da7748 has already completed/terminated?
1382e7bb-42eb-11e9-851d-605718da7748 has already completed/terminated?
Sending actor cancel request to ('streamer_2', '1342f952-42eb-11e9-b62d-605718da7748') on <Channel fd=688, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 60917), raddr=('127.0.0.1', 60934)>
Sending actor cancel request to ('streamer_1', '1303ccd8-42eb-11e9-b71a-605718da7748') on <Channel fd=672, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 60917), raddr=('127.0.0.1', 60927)>
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x0000023B2904C2E8>> was likely cancelled before it was started
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x00000203B8E7B240>> was likely cancelled before it was started
May have failed to cancel ('streamer_2', '1342f952-42eb-11e9-b62d-605718da7748')
May have failed to cancel ('streamer_1', '1303ccd8-42eb-11e9-b71a-605718da7748')
13030990-42eb-11e9-8459-605718da7748 has already completed/terminated?
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x000001523634B208>> was likely cancelled before it was started
---------------------------------------------------------------------------------------------------- Captured log setup -----------------------------------------------------------------------------------------------------
__init__.py                 65 WARNING  No actor could be found @ 127.0.0.1:2685
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '12b2fab6-42eb-11e9-b84c-605718da7748'):[<Channel fd=484, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 60918)>]?
_portal.py                 270 WARNING  Cancelling all streams with ('aggregator', '12b2fab6-42eb-11e9-b84c-605718da7748')
_portal.py                 108 WARNING  Cancelling stream 13030990-42eb-11e9-8459-605718da7748 to ('aggregator', '12b2fab6-42eb-11e9-b84c-605718da7748')
_portal.py                 291 WARNING  Sending actor cancel request to ('aggregator', '12b2fab6-42eb-11e9-b84c-605718da7748') on <Channel fd=484, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 60918)>
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '12b2fab6-42eb-11e9-b84c-605718da7748'):[<Channel fd=484, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 60918)>]?
_trionics.py               202 WARNING  Cancelling existing result waiter task for ('aggregator', '12b2fab6-42eb-11e9-b84c-605718da7748')
_portal.py                 300 WARNING  May have failed to cancel ('aggregator', '12b2fab6-42eb-11e9-b84c-605718da7748')
______________________________________________________________________________________________ test_not_fast_enough_quad[0.3] _______________________________________________________________________________________________

arb_addr = ('127.0.0.1', 2685), time_quad_ex = ([0, 1, 2, 3, 4, 5, ...], 3.8593993186950684), cancel_delay = 0.3

    @pytest.mark.parametrize(
        'cancel_delay',
        list(map(lambda i: i/10, range(3, 9)))
    )
    def test_not_fast_enough_quad(arb_addr, time_quad_ex, cancel_delay):
        """Verify we can cancel midway through the quad example and all actors
        cancel gracefully.
        """
        results, diff = time_quad_ex
        delay = max(diff - cancel_delay, 0)
        results = tractor.run(cancel_after, delay, arbiter_addr=arb_addr)
>       assert results is None
E       assert [0, 1, 2, 3, 4, 5, ...] is None

tests\test_streaming.py:193: AssertionError
--------------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------------
FINISHED ITERATING ('streamer_1', '154e30fa-42eb-11e9-b410-605718da7748')
FINISHED ITERATING ('streamer_2', '158ee2b8-42eb-11e9-992c-605718da7748')
FINISHED ITERATING in aggregator
WAITING on `ActorNursery` to finish
AGGREGATOR COMPLETE!
STREAM TIME = 1.8344135284423828
STREAM + SPAWN TIME = 2.3053078651428223
--------------------------------------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------------------------------------
Cancelling all streams with ('streamer_1', '154e30fa-42eb-11e9-b410-605718da7748')
Cancelling stream 15d11c7f-42eb-11e9-ac00-605718da7748 to ('streamer_1', '154e30fa-42eb-11e9-b410-605718da7748')
Cancelling all streams with ('streamer_2', '158ee2b8-42eb-11e9-992c-605718da7748')
Cancelling stream 15d11c7e-42eb-11e9-9804-605718da7748 to ('streamer_2', '158ee2b8-42eb-11e9-992c-605718da7748')
15d11c7f-42eb-11e9-ac00-605718da7748 has already completed/terminated?
15d11c7e-42eb-11e9-9804-605718da7748 has already completed/terminated?
Sending actor cancel request to ('streamer_1', '154e30fa-42eb-11e9-b410-605718da7748') on <Channel fd=628, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 60955), raddr=('127.0.0.1', 60964)>
Sending actor cancel request to ('streamer_2', '158ee2b8-42eb-11e9-992c-605718da7748') on <Channel fd=692, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 60955), raddr=('127.0.0.1', 60973)>
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x0000023FAFCDB208>> was likely cancelled before it was started
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x000001E9AF27B160>> was likely cancelled before it was started
May have failed to cancel ('streamer_1', '154e30fa-42eb-11e9-b410-605718da7748')
May have failed to cancel ('streamer_2', '158ee2b8-42eb-11e9-992c-605718da7748')
154ca99e-42eb-11e9-acd2-605718da7748 has already completed/terminated?
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x000001A9259A9F60>> was likely cancelled before it was started
----------------------------------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------------------------------
__init__.py                 65 WARNING  No actor could be found @ 127.0.0.1:2685
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '15060890-42eb-11e9-9567-605718da7748'):[<Channel fd=876, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 60956)>]?
_portal.py                 270 WARNING  Cancelling all streams with ('aggregator', '15060890-42eb-11e9-9567-605718da7748')
_portal.py                 108 WARNING  Cancelling stream 154ca99e-42eb-11e9-acd2-605718da7748 to ('aggregator', '15060890-42eb-11e9-9567-605718da7748')
_portal.py                 291 WARNING  Sending actor cancel request to ('aggregator', '15060890-42eb-11e9-9567-605718da7748') on <Channel fd=876, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 60956)>
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '15060890-42eb-11e9-9567-605718da7748'):[<Channel fd=876, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 60956)>]?
_trionics.py               202 WARNING  Cancelling existing result waiter task for ('aggregator', '15060890-42eb-11e9-9567-605718da7748')
_portal.py                 300 WARNING  May have failed to cancel ('aggregator', '15060890-42eb-11e9-9567-605718da7748')
______________________________________________________________________________________________ test_not_fast_enough_quad[0.4] _______________________________________________________________________________________________

arb_addr = ('127.0.0.1', 2685), time_quad_ex = ([0, 1, 2, 3, 4, 5, ...], 3.8593993186950684), cancel_delay = 0.4

    @pytest.mark.parametrize(
        'cancel_delay',
        list(map(lambda i: i/10, range(3, 9)))
    )
    def test_not_fast_enough_quad(arb_addr, time_quad_ex, cancel_delay):
        """Verify we can cancel midway through the quad example and all actors
        cancel gracefully.
        """
        results, diff = time_quad_ex
        delay = max(diff - cancel_delay, 0)
        results = tractor.run(cancel_after, delay, arbiter_addr=arb_addr)
>       assert results is None
E       assert [0, 1, 2, 3, 4, 5, ...] is None

tests\test_streaming.py:193: AssertionError
--------------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------------
FINISHED ITERATING ('streamer_2', '17dcee4c-42eb-11e9-b145-605718da7748')
FINISHED ITERATING ('streamer_1', '179c6378-42eb-11e9-84f6-605718da7748')
FINISHED ITERATING in aggregator
WAITING on `ActorNursery` to finish
AGGREGATOR COMPLETE!
STREAM TIME = 1.8151679039001465
STREAM + SPAWN TIME = 2.297607421875
--------------------------------------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------------------------------------
Cancelling all streams with ('streamer_2', '17dcee4c-42eb-11e9-b145-605718da7748')
Cancelling stream 181bce4c-42eb-11e9-82af-605718da7748 to ('streamer_2', '17dcee4c-42eb-11e9-b145-605718da7748')
Cancelling all streams with ('streamer_1', '179c6378-42eb-11e9-84f6-605718da7748')
Cancelling stream 181bce4d-42eb-11e9-a91f-605718da7748 to ('streamer_1', '179c6378-42eb-11e9-84f6-605718da7748')
181bce4c-42eb-11e9-82af-605718da7748 has already completed/terminated?
181bce4d-42eb-11e9-a91f-605718da7748 has already completed/terminated?
Sending actor cancel request to ('streamer_2', '17dcee4c-42eb-11e9-b145-605718da7748') on <Channel fd=728, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 60994), raddr=('127.0.0.1', 61010)>
Sending actor cancel request to ('streamer_1', '179c6378-42eb-11e9-84f6-605718da7748') on <Channel fd=712, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 60994), raddr=('127.0.0.1', 61003)>
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x000002E7A896B160>> was likely cancelled before it was started
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x000001D31805B0F0>> was likely cancelled before it was started
May have failed to cancel ('streamer_2', '17dcee4c-42eb-11e9-b145-605718da7748')
May have failed to cancel ('streamer_1', '179c6378-42eb-11e9-84f6-605718da7748')
179bedb4-42eb-11e9-a4e9-605718da7748 has already completed/terminated?
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x0000028402A5B400>> was likely cancelled before it was started
----------------------------------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------------------------------
__init__.py                 65 WARNING  No actor could be found @ 127.0.0.1:2685
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '17527870-42eb-11e9-9cf9-605718da7748'):[<Channel fd=908, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 60995)>]?
_portal.py                 270 WARNING  Cancelling all streams with ('aggregator', '17527870-42eb-11e9-9cf9-605718da7748')
_portal.py                 108 WARNING  Cancelling stream 179bedb4-42eb-11e9-a4e9-605718da7748 to ('aggregator', '17527870-42eb-11e9-9cf9-605718da7748')
_portal.py                 291 WARNING  Sending actor cancel request to ('aggregator', '17527870-42eb-11e9-9cf9-605718da7748') on <Channel fd=908, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 60995)>
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '17527870-42eb-11e9-9cf9-605718da7748'):[<Channel fd=908, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 60995)>]?
_trionics.py               202 WARNING  Cancelling existing result waiter task for ('aggregator', '17527870-42eb-11e9-9cf9-605718da7748')
_portal.py                 300 WARNING  May have failed to cancel ('aggregator', '17527870-42eb-11e9-9cf9-605718da7748')
______________________________________________________________________________________________ test_not_fast_enough_quad[0.5] _______________________________________________________________________________________________

arb_addr = ('127.0.0.1', 2685), time_quad_ex = ([0, 1, 2, 3, 4, 5, ...], 3.8593993186950684), cancel_delay = 0.5

    @pytest.mark.parametrize(
        'cancel_delay',
        list(map(lambda i: i/10, range(3, 9)))
    )
    def test_not_fast_enough_quad(arb_addr, time_quad_ex, cancel_delay):
        """Verify we can cancel midway through the quad example and all actors
        cancel gracefully.
        """
        results, diff = time_quad_ex
        delay = max(diff - cancel_delay, 0)
        results = tractor.run(cancel_after, delay, arbiter_addr=arb_addr)
>       assert results is None
E       assert [0, 1, 2, 3, 4, 5, ...] is None

tests\test_streaming.py:193: AssertionError
--------------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------------
FINISHED ITERATING ('streamer_1', '19e190ba-42eb-11e9-bfb7-605718da7748')
FINISHED ITERATING ('streamer_2', '1a210af6-42eb-11e9-abb3-605718da7748')
FINISHED ITERATING in aggregator
WAITING on `ActorNursery` to finish
AGGREGATOR COMPLETE!
STREAM TIME = 1.8125734329223633
STREAM + SPAWN TIME = 2.2616734504699707
--------------------------------------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------------------------------------
Cancelling all streams with ('streamer_1', '19e190ba-42eb-11e9-bfb7-605718da7748')
Cancelling stream 1a63b9d2-42eb-11e9-b18b-605718da7748 to ('streamer_1', '19e190ba-42eb-11e9-bfb7-605718da7748')
Cancelling all streams with ('streamer_2', '1a210af6-42eb-11e9-abb3-605718da7748')
Cancelling stream 1a63b9d3-42eb-11e9-a62c-605718da7748 to ('streamer_2', '1a210af6-42eb-11e9-abb3-605718da7748')
1a63b9d2-42eb-11e9-b18b-605718da7748 has already completed/terminated?
1a63b9d3-42eb-11e9-a62c-605718da7748 has already completed/terminated?
Sending actor cancel request to ('streamer_1', '19e190ba-42eb-11e9-bfb7-605718da7748') on <Channel fd=552, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 61033), raddr=('127.0.0.1', 61042)>
Sending actor cancel request to ('streamer_2', '1a210af6-42eb-11e9-abb3-605718da7748') on <Channel fd=568, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 61033), raddr=('127.0.0.1', 61050)>
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x0000026A475FB278>> was likely cancelled before it was started
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x00000270960FB240>> was likely cancelled before it was started
May have failed to cancel ('streamer_1', '19e190ba-42eb-11e9-bfb7-605718da7748')
May have failed to cancel ('streamer_2', '1a210af6-42eb-11e9-abb3-605718da7748')
19e11b8c-42eb-11e9-9cea-605718da7748 has already completed/terminated?
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x0000020AD112B0B8>> was likely cancelled before it was started
----------------------------------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------------------------------
__init__.py                 65 WARNING  No actor could be found @ 127.0.0.1:2685
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '199ce2b6-42eb-11e9-8fa9-605718da7748'):[<Channel fd=960, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61034)>]?
_portal.py                 270 WARNING  Cancelling all streams with ('aggregator', '199ce2b6-42eb-11e9-8fa9-605718da7748')
_portal.py                 108 WARNING  Cancelling stream 19e11b8c-42eb-11e9-9cea-605718da7748 to ('aggregator', '199ce2b6-42eb-11e9-8fa9-605718da7748')
_portal.py                 291 WARNING  Sending actor cancel request to ('aggregator', '199ce2b6-42eb-11e9-8fa9-605718da7748') on <Channel fd=960, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61034)>
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '199ce2b6-42eb-11e9-8fa9-605718da7748'):[<Channel fd=960, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61034)>]?
_trionics.py               202 WARNING  Cancelling existing result waiter task for ('aggregator', '199ce2b6-42eb-11e9-8fa9-605718da7748')
_portal.py                 300 WARNING  May have failed to cancel ('aggregator', '199ce2b6-42eb-11e9-8fa9-605718da7748')
______________________________________________________________________________________________ test_not_fast_enough_quad[0.6] _______________________________________________________________________________________________

arb_addr = ('127.0.0.1', 2685), time_quad_ex = ([0, 1, 2, 3, 4, 5, ...], 3.8593993186950684), cancel_delay = 0.6

    @pytest.mark.parametrize(
        'cancel_delay',
        list(map(lambda i: i/10, range(3, 9)))
    )
    def test_not_fast_enough_quad(arb_addr, time_quad_ex, cancel_delay):
        """Verify we can cancel midway through the quad example and all actors
        cancel gracefully.
        """
        results, diff = time_quad_ex
        delay = max(diff - cancel_delay, 0)
        results = tractor.run(cancel_after, delay, arbiter_addr=arb_addr)
>       assert results is None
E       assert [0, 1, 2, 3, 4, 5, ...] is None

tests\test_streaming.py:193: AssertionError
--------------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------------
FINISHED ITERATING ('streamer_1', '1c26977a-42eb-11e9-a690-605718da7748')
FINISHED ITERATING ('streamer_2', '1c659c76-42eb-11e9-af43-605718da7748')
FINISHED ITERATING in aggregator
WAITING on `ActorNursery` to finish
AGGREGATOR COMPLETE!
STREAM TIME = 1.7910356521606445
STREAM + SPAWN TIME = 2.251007318496704
--------------------------------------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------------------------------------
Cancelling all streams with ('streamer_2', '1c659c76-42eb-11e9-af43-605718da7748')
Cancelling stream 1ca4c792-42eb-11e9-804a-605718da7748 to ('streamer_2', '1c659c76-42eb-11e9-af43-605718da7748')
Cancelling all streams with ('streamer_1', '1c26977a-42eb-11e9-a690-605718da7748')
Cancelling stream 1ca4c793-42eb-11e9-8e50-605718da7748 to ('streamer_1', '1c26977a-42eb-11e9-a690-605718da7748')
1ca4c793-42eb-11e9-8e50-605718da7748 has already completed/terminated?
1ca4c792-42eb-11e9-804a-605718da7748 has already completed/terminated?
Sending actor cancel request to ('streamer_1', '1c26977a-42eb-11e9-a690-605718da7748') on <Channel fd=504, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 61073), raddr=('127.0.0.1', 61082)>
Sending actor cancel request to ('streamer_2', '1c659c76-42eb-11e9-af43-605718da7748') on <Channel fd=648, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 61073), raddr=('127.0.0.1', 61089)>
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x000001E9678CB128>> was likely cancelled before it was started
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x00000200F7E3B390>> was likely cancelled before it was started
May have failed to cancel ('streamer_1', '1c26977a-42eb-11e9-a690-605718da7748')
May have failed to cancel ('streamer_2', '1c659c76-42eb-11e9-af43-605718da7748')
1c23ff68-42eb-11e9-af8f-605718da7748 has already completed/terminated?
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x000001F3295EB240>> was likely cancelled before it was started
----------------------------------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------------------------------
__init__.py                 65 WARNING  No actor could be found @ 127.0.0.1:2685
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '1be019b6-42eb-11e9-8a4f-605718da7748'):[<Channel fd=960, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61074)>]?
_portal.py                 270 WARNING  Cancelling all streams with ('aggregator', '1be019b6-42eb-11e9-8a4f-605718da7748')
_portal.py                 108 WARNING  Cancelling stream 1c23ff68-42eb-11e9-af8f-605718da7748 to ('aggregator', '1be019b6-42eb-11e9-8a4f-605718da7748')
_portal.py                 291 WARNING  Sending actor cancel request to ('aggregator', '1be019b6-42eb-11e9-8a4f-605718da7748') on <Channel fd=960, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61074)>
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '1be019b6-42eb-11e9-8a4f-605718da7748'):[<Channel fd=960, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61074)>]?
_trionics.py               202 WARNING  Cancelling existing result waiter task for ('aggregator', '1be019b6-42eb-11e9-8a4f-605718da7748')
_portal.py                 300 WARNING  May have failed to cancel ('aggregator', '1be019b6-42eb-11e9-8a4f-605718da7748')
______________________________________________________________________________________________ test_not_fast_enough_quad[0.7] _______________________________________________________________________________________________

arb_addr = ('127.0.0.1', 2685), time_quad_ex = ([0, 1, 2, 3, 4, 5, ...], 3.8593993186950684), cancel_delay = 0.7

    @pytest.mark.parametrize(
        'cancel_delay',
        list(map(lambda i: i/10, range(3, 9)))
    )
    def test_not_fast_enough_quad(arb_addr, time_quad_ex, cancel_delay):
        """Verify we can cancel midway through the quad example and all actors
        cancel gracefully.
        """
        results, diff = time_quad_ex
        delay = max(diff - cancel_delay, 0)
        results = tractor.run(cancel_after, delay, arbiter_addr=arb_addr)
>       assert results is None
E       assert [0, 1, 2, 3, 4, 5, ...] is None

tests\test_streaming.py:193: AssertionError
--------------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------------
FINISHED ITERATING ('streamer_1', '1e67b25e-42eb-11e9-bd1a-605718da7748')
FINISHED ITERATING ('streamer_2', '1ea8075c-42eb-11e9-9d1a-605718da7748')
FINISHED ITERATING in aggregator
WAITING on `ActorNursery` to finish
AGGREGATOR COMPLETE!
STREAM TIME = 1.82096529006958
STREAM + SPAWN TIME = 2.2509922981262207
--------------------------------------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------------------------------------
Cancelling all streams with ('streamer_1', '1e67b25e-42eb-11e9-bd1a-605718da7748')
Cancelling stream 1ee88767-42eb-11e9-ba42-605718da7748 to ('streamer_1', '1e67b25e-42eb-11e9-bd1a-605718da7748')
Cancelling all streams with ('streamer_2', '1ea8075c-42eb-11e9-9d1a-605718da7748')
Cancelling stream 1ee88766-42eb-11e9-ac48-605718da7748 to ('streamer_2', '1ea8075c-42eb-11e9-9d1a-605718da7748')
1ee88767-42eb-11e9-ba42-605718da7748 has already completed/terminated?
1ee88766-42eb-11e9-ac48-605718da7748 has already completed/terminated?
Sending actor cancel request to ('streamer_2', '1ea8075c-42eb-11e9-9d1a-605718da7748') on <Channel fd=756, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 61112), raddr=('127.0.0.1', 61129)>
Sending actor cancel request to ('streamer_1', '1e67b25e-42eb-11e9-bd1a-605718da7748') on <Channel fd=660, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 61112), raddr=('127.0.0.1', 61122)>
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x000002109EACB2B0>> was likely cancelled before it was started
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x0000021C9353B160>> was likely cancelled before it was started
May have failed to cancel ('streamer_2', '1ea8075c-42eb-11e9-9d1a-605718da7748')
May have failed to cancel ('streamer_1', '1e67b25e-42eb-11e9-bd1a-605718da7748')
1e673dcc-42eb-11e9-bd81-605718da7748 has already completed/terminated?
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x000002A443C5B198>> was likely cancelled before it was started
----------------------------------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------------------------------
__init__.py                 65 WARNING  No actor could be found @ 127.0.0.1:2685
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '1e25c6ee-42eb-11e9-990a-605718da7748'):[<Channel fd=632, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61113)>]?
_portal.py                 270 WARNING  Cancelling all streams with ('aggregator', '1e25c6ee-42eb-11e9-990a-605718da7748')
_portal.py                 108 WARNING  Cancelling stream 1e673dcc-42eb-11e9-bd81-605718da7748 to ('aggregator', '1e25c6ee-42eb-11e9-990a-605718da7748')
_portal.py                 291 WARNING  Sending actor cancel request to ('aggregator', '1e25c6ee-42eb-11e9-990a-605718da7748') on <Channel fd=632, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61113)>
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '1e25c6ee-42eb-11e9-990a-605718da7748'):[<Channel fd=632, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61113)>]?
_trionics.py               202 WARNING  Cancelling existing result waiter task for ('aggregator', '1e25c6ee-42eb-11e9-990a-605718da7748')
_portal.py                 300 WARNING  May have failed to cancel ('aggregator', '1e25c6ee-42eb-11e9-990a-605718da7748')
______________________________________________________________________________________________ test_not_fast_enough_quad[0.8] _______________________________________________________________________________________________

arb_addr = ('127.0.0.1', 2685), time_quad_ex = ([0, 1, 2, 3, 4, 5, ...], 3.8593993186950684), cancel_delay = 0.8

    @pytest.mark.parametrize(
        'cancel_delay',
        list(map(lambda i: i/10, range(3, 9)))
    )
    def test_not_fast_enough_quad(arb_addr, time_quad_ex, cancel_delay):
        """Verify we can cancel midway through the quad example and all actors
        cancel gracefully.
        """
        results, diff = time_quad_ex
        delay = max(diff - cancel_delay, 0)
        results = tractor.run(cancel_after, delay, arbiter_addr=arb_addr)
>       assert results is None
E       assert [0, 1, 2, 3, 4, 5, ...] is None

tests\test_streaming.py:193: AssertionError
--------------------------------------------------------------------------------------------------- Captured stdout call ----------------------------------------------------------------------------------------------------
FINISHED ITERATING ('streamer_1', '20be269c-42eb-11e9-a07a-605718da7748')
FINISHED ITERATING ('streamer_2', '20fdf29a-42eb-11e9-b37d-605718da7748')
FINISHED ITERATING in aggregator
WAITING on `ActorNursery` to finish
AGGREGATOR COMPLETE!
STREAM TIME = 1.8536937236785889
STREAM + SPAWN TIME = 2.4096434116363525
--------------------------------------------------------------------------------------------------- Captured stderr call ----------------------------------------------------------------------------------------------------
Cancelling all streams with ('streamer_1', '20be269c-42eb-11e9-a07a-605718da7748')
Cancelling stream 213f4418-42eb-11e9-9d84-605718da7748 to ('streamer_1', '20be269c-42eb-11e9-a07a-605718da7748')
Cancelling all streams with ('streamer_2', '20fdf29a-42eb-11e9-b37d-605718da7748')
Cancelling stream 213f4419-42eb-11e9-b5f2-605718da7748 to ('streamer_2', '20fdf29a-42eb-11e9-b37d-605718da7748')
213f4418-42eb-11e9-9d84-605718da7748 has already completed/terminated?
213f4419-42eb-11e9-b5f2-605718da7748 has already completed/terminated?
Sending actor cancel request to ('streamer_1', '20be269c-42eb-11e9-a07a-605718da7748') on <Channel fd=744, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 61154), raddr=('127.0.0.1', 61162)>
Sending actor cancel request to ('streamer_2', '20fdf29a-42eb-11e9-b37d-605718da7748') on <Channel fd=768, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 61154), raddr=('127.0.0.1', 61170)>
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x00000272911EB358>> was likely cancelled before it was started
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x00000132E72A9FD0>> was likely cancelled before it was started
May have failed to cancel ('streamer_1', '20be269c-42eb-11e9-a07a-605718da7748')
May have failed to cancel ('streamer_2', '20fdf29a-42eb-11e9-b37d-605718da7748')
20bdb13e-42eb-11e9-8215-605718da7748 has already completed/terminated?
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x00000131852DB1D0>> was likely cancelled before it was started
----------------------------------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------------------------------
__init__.py                 65 WARNING  No actor could be found @ 127.0.0.1:2685
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '2069031c-42eb-11e9-9417-605718da7748'):[<Channel fd=976, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61155)>]?
_portal.py                 270 WARNING  Cancelling all streams with ('aggregator', '2069031c-42eb-11e9-9417-605718da7748')
_portal.py                 108 WARNING  Cancelling stream 20bdb13e-42eb-11e9-8215-605718da7748 to ('aggregator', '2069031c-42eb-11e9-9417-605718da7748')
_portal.py                 291 WARNING  Sending actor cancel request to ('aggregator', '2069031c-42eb-11e9-9417-605718da7748') on <Channel fd=976, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61155)>
_actor.py                  268 WARNING  already have channel(s) for ('aggregator', '2069031c-42eb-11e9-9417-605718da7748'):[<Channel fd=976, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 2685), raddr=('127.0.0.1', 61155)>]?
_trionics.py               202 WARNING  Cancelling existing result waiter task for ('aggregator', '2069031c-42eb-11e9-9417-605718da7748')
_portal.py                 300 WARNING  May have failed to cancel ('aggregator', '2069031c-42eb-11e9-9417-605718da7748')
=========================================================================================== 7 failed, 35 passed in 112.58 seconds ===========================================================================================

```
</details>