### PR TITLE
Stream functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -280,8 +280,60 @@ to all others with ease over standard network protocols).
 .. _Executor: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor
 
 
-Async IPC using *portals*
-*************************
+Cancellation
+************
+``tractor`` supports ``trio``'s cancellation_ system verbatim.
+Cancelling a nursery block cancels all actors spawned by it.
+Eventually ``tractor`` plans to support different `supervision strategies`_ like ``erlang``.
+
+.. _supervision strategies: http://erlang.org/doc/man/supervisor.html#sup_flags
+
+
+Remote error propagation
+************************
+Any task invoked in a remote actor should ship any error(s) back to the calling
+actor where it is raised and expected to be dealt with. This way remote actors
+are never cancelled unless explicitly asked or there's a bug in ``tractor`` itself.
+
+.. code:: python
+
+    async def assert_err():
+        assert 0
+
+
+    async def main():
+        async with tractor.open_nursery() as n:
+            real_actors = []
+            for i in range(3):
+                real_actors.append(await n.start_actor(
+                    f'actor_{i}',
+                    rpc_module_paths=[__name__],
+                ))
+
+            # start one actor that will fail immediately
+            await n.run_in_actor('extra', assert_err)
+
+        # should error here with a ``RemoteActorError`` containing
+        # an ``AssertionError`` and all the other actors have been cancelled
+
+    try:
+        # also raises
+        tractor.run(main)
+    except tractor.RemoteActorError:
+        print("Look Maa that actor failed hard, hehhh!")
+
+
+You'll notice the nursery cancellation conducts a *one-cancels-all*
+supervisory strategy `exactly like trio`_. The plan is to add more
+`erlang strategies`_ in the near future by allowing nurseries to accept
+a ``Supervisor`` type.
+
+.. _exactly like trio: https://trio.readthedocs.io/en/latest/reference-core.html#cancellation-semantics
+.. _erlang strategies: http://learnyousomeerlang.com/supervisors
+
+
+IPC using *portals*
+*******************
 ``tractor`` introduces the concept of a *portal* which is an API
 borrowed_ from ``trio``. A portal may seem similar to the idea of
 a RPC future_ except a *portal* allows invoking remote *async* functions and
@@ -305,10 +357,26 @@ channels_ system or shipping code over the network.
 
 This *portal* approach turns out to be paricularly exciting with the
 introduction of `asynchronous generators`_ in Python 3.6! It means that
-actors can compose nicely in a data processing pipeline.
+actors can compose nicely in a data streaming pipeline.
 
-As an example here's an actor that streams for 1 second from a remote async
-generator function running in a separate actor:
+
+Streaming
+*********
+By now you've figured out that ``tractor`` lets you spawn
+process based actors that can invoke cross-process async functions
+between each other and all with structured concurrency built in, but,
+the **real power** is the ability to accomplish cross-process *streaming*.
+
+
+Asynchronous generators
++++++++++++++++++++++++
+The default streaming function is simply an async generator definition.
+Every value *yielded* from the generator is delivered to the calling
+portal exactly like if you had invoked the function in-process meaning
+you can ``async for`` to receive each value on the calling side.
+
+As an example here's a parent actor that streams for 1 second from a
+spawned subactor:
 
 .. code:: python
 
@@ -346,10 +414,79 @@ generator function running in a separate actor:
 
     tractor.run(main)
 
+By default async generator functions are treated as inter-actor
+*streams* when invoked via a portal (how else could you really interface
+with them anyway) so no special syntax to denote the streaming *service*
+is necessary.
+
+
+Channels and Contexts
++++++++++++++++++++++
+If you aren't fond of having to write an async generator to stream data
+between actors (or need something more flexible) you can instead use a
+``Context``. A context wraps an actor-local spawned task and a ``Channel``
+so that tasks executing across multiple processes can stream data
+to one another using a low level, request oriented API.
+
+``Channel`` is the API which wraps an underlying *transport* and *interchange*
+format to enable *inter-actor-communication*. In its present state ``tractor``
+uses TCP and msgpack_.
+
+As an example if you wanted to create a streaming server without writing
+an async generator that *yields* values you instead define an async
+function:
+
+.. code:: python
+
+   async def streamer(ctx: tractor.Context, rate: int = 2) -> None:
+      """A simple web response streaming server.
+      """
+      while True:
+         val = await web_request('http://data.feed.com')
+
+         # this is the same as ``yield`` in the async gen case
+         await ctx.send_yield(val)
+
+         await trio.sleep(1 / rate)
+
+
+All that's required is declaring a ``ctx`` argument name somewhere in
+your function signature and ``tractor`` will treat the async function
+like an async generator - as a streaming function from the client side.
+This turns out to be handy particularly if you have
+multiple tasks streaming responses concurrently:
+
+.. code:: python
+
+   async def streamer(ctx: tractor.Context, rate: int = 2) -> None:
+      """A simple web response streaming server.
+      """
+      while True:
+         val = await web_request(url)
+
+         # this is the same as ``yield`` in the async gen case
+         await ctx.send_yield(val)
+
+         await trio.sleep(1 / rate)
+
+
+   async def stream_multiple_sources(
+      ctx: tractor.Context, sources: List[str]
+   ) -> None:
+      async with trio.open_nursery() as n:
+         for url in sources:
+            n.start_soon(streamer, ctx, url)
+
+
+The context notion comes from the context_ in nanomsg_.
+
+.. _context: https://nanomsg.github.io/nng/man/tip/nng_ctx.5
+.. _msgpack: https://en.wikipedia.org/wiki/MessagePack
+
 
 
 A full fledged streaming service
-********************************
+++++++++++++++++++++++++++++++++
 Alright, let's get fancy.
 
 Say you wanted to spawn two actors which each pull data feeds from
@@ -471,58 +608,6 @@ as ``multiprocessing`` calls it) which is running ``main()``.
 .. _remote function execution: https://codespeak.net/execnet/example/test_info.html#remote-exec-a-function-avoiding-inlined-source-part-i
 
 
-Cancellation
-************
-``tractor`` supports ``trio``'s cancellation_ system verbatim.
-Cancelling a nursery block cancels all actors spawned by it.
-Eventually ``tractor`` plans to support different `supervision strategies`_ like ``erlang``.
-
-.. _supervision strategies: http://erlang.org/doc/man/supervisor.html#sup_flags
-
-
-Remote error propagation
-************************
-Any task invoked in a remote actor should ship any error(s) back to the calling
-actor where it is raised and expected to be dealt with. This way remote actors
-are never cancelled unless explicitly asked or there's a bug in ``tractor`` itself.
-
-.. code:: python
-
-    async def assert_err():
-        assert 0
-
-
-    async def main():
-        async with tractor.open_nursery() as n:
-            real_actors = []
-            for i in range(3):
-                real_actors.append(await n.start_actor(
-                    f'actor_{i}',
-                    rpc_module_paths=[__name__],
-                ))
-
-            # start one actor that will fail immediately
-            await n.run_in_actor('extra', assert_err)
-
-        # should error here with a ``RemoteActorError`` containing
-        # an ``AssertionError`` and all the other actors have been cancelled
-
-    try:
-        # also raises
-        tractor.run(main)
-    except tractor.RemoteActorError:
-        print("Look Maa that actor failed hard, hehhh!")
-
-
-You'll notice the nursery cancellation conducts a *one-cancels-all*
-supervisory strategy `exactly like trio`_. The plan is to add more
-`erlang strategies`_ in the near future by allowing nurseries to accept
-a ``Supervisor`` type.
-
-.. _exactly like trio: https://trio.readthedocs.io/en/latest/reference-core.html#cancellation-semantics
-.. _erlang strategies: http://learnyousomeerlang.com/supervisors
-
-
 Actor local variables
 *********************
 Although ``tractor`` uses a *shared-nothing* architecture between processes
@@ -556,8 +641,8 @@ a convenience for passing simple data to newly spawned actors); building
 out a state sharing system per-actor is totally up to you.
 
 
-How do actors find each other (a poor man's *service discovery*)?
-*****************************************************************
+Service Discovery
+*****************
 Though it will be built out much more in the near future, ``tractor``
 currently keeps track of actors by ``(name: str, id: str)`` using a
 special actor called the *arbiter*. Currently the *arbiter* must exist
@@ -588,70 +673,6 @@ find an actor's socket address by name use the ``find_actor()`` function:
 
 The ``name`` value you should pass to ``find_actor()`` is the one you passed as the
 *first* argument to either ``tractor.run()`` or ``ActorNursery.start_actor()``.
-
-
-Streaming using channels and contexts
-*************************************
-``Channel`` is the API which wraps an underlying *transport* and *interchange*
-format to enable *inter-actor-communication*. In its present state ``tractor``
-uses TCP and msgpack_.
-
-If you aren't fond of having to write an async generator to stream data
-between actors (or need something more flexible) you can instead use a
-``Context``. A context wraps an actor-local spawned task and a ``Channel``
-so that tasks executing across multiple processes can stream data
-to one another using a low level, request oriented API.
-
-As an example if you wanted to create a streaming server without writing
-an async generator that *yields* values you instead define an async
-function:
-
-.. code:: python
-
-   async def streamer(ctx: tractor.Context, rate: int = 2) -> None:
-      """A simple web response streaming server.
-      """
-      while True:
-         val = await web_request('http://data.feed.com')
-
-         # this is the same as ``yield`` in the async gen case
-         await ctx.send_yield(val)
-
-         await trio.sleep(1 / rate)
-
-
-All that's required is declaring a ``ctx`` argument name somewhere in
-your function signature and ``tractor`` will treat the async function
-like an async generator - as a streaming function from the client side.
-This turns out to be handy particularly if you have
-multiple tasks streaming responses concurrently:
-
-.. code:: python
-
-   async def streamer(ctx: tractor.Context, rate: int = 2) -> None:
-      """A simple web response streaming server.
-      """
-      while True:
-         val = await web_request(url)
-
-         # this is the same as ``yield`` in the async gen case
-         await ctx.send_yield(val)
-
-         await trio.sleep(1 / rate)
-
-
-   async def stream_multiple_sources(
-      ctx: tractor.Context, sources: List[str]
-   ) -> None:
-      async with trio.open_nursery() as n:
-         for url in sources:
-            n.start_soon(streamer, ctx, url)
-
-
-The context notion comes from the context_ in nanomsg_.
-
-.. _context: https://nanomsg.github.io/nng/man/tip/nng_ctx.5
-.. _msgpack: https://en.wikipedia.org/wiki/MessagePack
 
 
 Running actors standalone

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -11,7 +11,8 @@ import trio  # type: ignore
 from trio import MultiError
 
 from . import log
-from ._ipc import _connect_chan, Channel, Context
+from ._ipc import _connect_chan, Channel
+from ._streaming import Context, stream
 from ._discovery import get_arbiter, find_actor, wait_for_actor
 from ._actor import Actor, _start_actor, Arbiter
 from ._trionics import open_nursery
@@ -29,6 +30,7 @@ __all__ = [
     'wait_for_actor',
     'Channel',
     'Context',
+    'stream',
     'MultiError',
     'RemoteActorError',
     'ModuleNotExposed',

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -12,9 +12,8 @@ from trio import MultiError
 
 from . import log
 from ._ipc import _connect_chan, Channel, Context
-from ._actor import (
-    Actor, _start_actor, Arbiter, get_arbiter, find_actor, wait_for_actor
-)
+from ._discovery import get_arbiter, find_actor, wait_for_actor
+from ._actor import Actor, _start_actor, Arbiter
 from ._trionics import open_nursery
 from ._state import current_actor
 from ._exceptions import RemoteActorError, ModuleNotExposed

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -41,26 +41,16 @@ async def _invoke(
     kwargs: Dict[str, Any],
     task_status=trio.TASK_STATUS_IGNORED
 ):
-    """Invoke local func and return results over provided channel.
+    """Invoke local func and deliver result(s) over provided channel.
     """
-    sig = inspect.signature(func)
     treat_as_gen = False
     cs = None
     cancel_scope = trio.CancelScope()
     ctx = Context(chan, cid, cancel_scope)
     _context.set(ctx)
     if getattr(func, '_tractor_stream_function', False):
-        if 'ctx' not in sig.parameters:
-            raise TypeError(
-                "The first argument to the stream function "
-                f"{func.__name__} must be `ctx: tractor.Context`"
-            )
+        # handle decorated ``@tractor.stream`` async functions
         kwargs['ctx'] = ctx
-        # TODO: eventually we want to be more stringent
-        # about what is considered a far-end async-generator.
-        # Right now both actual async gens and any async
-        # function which declares a `ctx` kwarg in its
-        # signature will be treated as one.
         treat_as_gen = True
     try:
         is_async_partial = False

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -8,25 +8,21 @@ import importlib
 import inspect
 import uuid
 import typing
-from typing import Dict, List, Tuple, Any, Optional, Union
+from typing import Dict, List, Tuple, Any, Optional
 
 import trio  # type: ignore
-from async_generator import asynccontextmanager, aclosing
+from async_generator import aclosing
 
-from ._ipc import Channel, _connect_chan, Context
+from ._ipc import Channel, Context
 from .log import get_console_log, get_logger
 from ._exceptions import (
     pack_error,
     unpack_error,
     ModuleNotExposed
 )
-from ._portal import (
-    Portal,
-    open_portal,
-    LocalPortal,
-)
+from ._discovery import get_arbiter
+from ._portal import Portal
 from . import _state
-from ._state import current_actor
 
 
 log = get_logger('tractor')
@@ -869,66 +865,3 @@ async def _start_actor(
     log.info("Completed async main")
 
     return result
-
-
-@asynccontextmanager
-async def get_arbiter(
-    host: str, port: int
-) -> typing.AsyncGenerator[Union[Portal, LocalPortal], None]:
-    """Return a portal instance connected to a local or remote
-    arbiter.
-    """
-    actor = current_actor()
-    if not actor:
-        raise RuntimeError("No actor instance has been defined yet?")
-
-    if actor.is_arbiter:
-        # we're already the arbiter
-        # (likely a re-entrant call from the arbiter actor)
-        yield LocalPortal(actor)
-    else:
-        async with _connect_chan(host, port) as chan:
-            async with open_portal(chan) as arb_portal:
-                yield arb_portal
-
-
-@asynccontextmanager
-async def find_actor(
-    name: str, arbiter_sockaddr: Tuple[str, int] = None
-) -> typing.AsyncGenerator[Optional[Portal], None]:
-    """Ask the arbiter to find actor(s) by name.
-
-    Returns a connected portal to the last registered matching actor
-    known to the arbiter.
-    """
-    actor = current_actor()
-    async with get_arbiter(*arbiter_sockaddr or actor._arb_addr) as arb_portal:
-        sockaddr = await arb_portal.run('self', 'find_actor', name=name)
-        # TODO: return portals to all available actors - for now just
-        # the last one that registered
-        if name == 'arbiter' and actor.is_arbiter:
-            raise RuntimeError("The current actor is the arbiter")
-        elif sockaddr:
-            async with _connect_chan(*sockaddr) as chan:
-                async with open_portal(chan) as portal:
-                    yield portal
-        else:
-            yield None
-
-
-@asynccontextmanager
-async def wait_for_actor(
-    name: str,
-    arbiter_sockaddr: Tuple[str, int] = None
-) -> typing.AsyncGenerator[Portal, None]:
-    """Wait on an actor to register with the arbiter.
-
-    A portal to the first registered actor is returned.
-    """
-    actor = current_actor()
-    async with get_arbiter(*arbiter_sockaddr or actor._arb_addr) as arb_portal:
-        sockaddrs = await arb_portal.run('self', 'wait_for_actor', name=name)
-        sockaddr = sockaddrs[-1]
-        async with _connect_chan(*sockaddr) as chan:
-            async with open_portal(chan) as portal:
-                yield portal

--- a/tractor/_discovery.py
+++ b/tractor/_discovery.py
@@ -1,0 +1,77 @@
+"""
+Actor discovery API.
+"""
+import typing
+from typing import Tuple, Optional, Union
+from async_generator import asynccontextmanager
+
+from ._ipc import _connect_chan
+from ._portal import (
+    Portal,
+    open_portal,
+    LocalPortal,
+)
+from ._state import current_actor
+
+
+@asynccontextmanager
+async def get_arbiter(
+    host: str, port: int
+) -> typing.AsyncGenerator[Union[Portal, LocalPortal], None]:
+    """Return a portal instance connected to a local or remote
+    arbiter.
+    """
+    actor = current_actor()
+    if not actor:
+        raise RuntimeError("No actor instance has been defined yet?")
+
+    if actor.is_arbiter:
+        # we're already the arbiter
+        # (likely a re-entrant call from the arbiter actor)
+        yield LocalPortal(actor)
+    else:
+        async with _connect_chan(host, port) as chan:
+            async with open_portal(chan) as arb_portal:
+                yield arb_portal
+
+
+@asynccontextmanager
+async def find_actor(
+    name: str, arbiter_sockaddr: Tuple[str, int] = None
+) -> typing.AsyncGenerator[Optional[Portal], None]:
+    """Ask the arbiter to find actor(s) by name.
+
+    Returns a connected portal to the last registered matching actor
+    known to the arbiter.
+    """
+    actor = current_actor()
+    async with get_arbiter(*arbiter_sockaddr or actor._arb_addr) as arb_portal:
+        sockaddr = await arb_portal.run('self', 'find_actor', name=name)
+        # TODO: return portals to all available actors - for now just
+        # the last one that registered
+        if name == 'arbiter' and actor.is_arbiter:
+            raise RuntimeError("The current actor is the arbiter")
+        elif sockaddr:
+            async with _connect_chan(*sockaddr) as chan:
+                async with open_portal(chan) as portal:
+                    yield portal
+        else:
+            yield None
+
+
+@asynccontextmanager
+async def wait_for_actor(
+    name: str,
+    arbiter_sockaddr: Tuple[str, int] = None
+) -> typing.AsyncGenerator[Portal, None]:
+    """Wait on an actor to register with the arbiter.
+
+    A portal to the first registered actor is returned.
+    """
+    actor = current_actor()
+    async with get_arbiter(*arbiter_sockaddr or actor._arb_addr) as arb_portal:
+        sockaddrs = await arb_portal.run('self', 'wait_for_actor', name=name)
+        sockaddr = sockaddrs[-1]
+        async with _connect_chan(*sockaddr) as chan:
+            async with open_portal(chan) as portal:
+                yield portal

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -1,7 +1,6 @@
 """
 Inter-process comms abstractions
 """
-from dataclasses import dataclass
 import typing
 from typing import Any, Tuple, Optional
 
@@ -203,25 +202,6 @@ class Channel:
 
     def connected(self) -> bool:
         return self.msgstream.connected() if self.msgstream else False
-
-
-@dataclass(frozen=True)
-class Context:
-    """An IAC (inter-actor communication) context.
-
-    Allows maintaining task or protocol specific state between communicating
-    actors. A unique context is created on the receiving end for every request
-    to a remote actor.
-    """
-    chan: Channel
-    cid: str
-    cancel_scope: trio.CancelScope
-
-    async def send_yield(self, data: Any) -> None:
-        await self.chan.send({'yield': data, 'cid': self.cid})
-
-    async def send_stop(self) -> None:
-        await self.chan.send({'stop': True, 'cid': self.cid})
 
 
 @asynccontextmanager

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -215,10 +215,7 @@ class Context:
     """
     chan: Channel
     cid: str
-
-    # TODO: we should probably attach the actor-task
-    # cancel scope here now that trio is exposing it
-    # as a public object
+    cancel_scope: trio.CancelScope
 
     async def send_yield(self, data: Any) -> None:
         await self.chan.send({'yield': data, 'cid': self.cid})

--- a/tractor/_streaming.py
+++ b/tractor/_streaming.py
@@ -1,3 +1,4 @@
+import inspect
 from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
@@ -39,4 +40,10 @@ def stream(func):
     """Mark an async function as a streaming routine.
     """
     func._tractor_stream_function = True
+    sig = inspect.signature(func)
+    if 'ctx' not in sig.parameters:
+        raise TypeError(
+            "The first argument to the stream function "
+            f"{func.__name__} must be `ctx: tractor.Context`"
+        )
     return func

--- a/tractor/_streaming.py
+++ b/tractor/_streaming.py
@@ -1,4 +1,4 @@
-import contextvars
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
 
@@ -7,7 +7,7 @@ import trio
 from ._ipc import Channel
 
 
-_context = contextvars.ContextVar('context')
+_context: ContextVar['Context'] = ContextVar('context')
 
 
 @dataclass(frozen=True)
@@ -30,8 +30,7 @@ class Context:
 
 
 def current_context():
-    """Get the current streaming task's context instance.
-
+    """Get the current task's context instance.
     """
     return _context.get()
 

--- a/tractor/_streaming.py
+++ b/tractor/_streaming.py
@@ -1,0 +1,43 @@
+import contextvars
+from dataclasses import dataclass
+from typing import Any
+
+import trio
+
+from ._ipc import Channel
+
+
+_context = contextvars.ContextVar('context')
+
+
+@dataclass(frozen=True)
+class Context:
+    """An IAC (inter-actor communication) context.
+
+    Allows maintaining task or protocol specific state between communicating
+    actors. A unique context is created on the receiving end for every request
+    to a remote actor.
+    """
+    chan: Channel
+    cid: str
+    cancel_scope: trio.CancelScope
+
+    async def send_yield(self, data: Any) -> None:
+        await self.chan.send({'yield': data, 'cid': self.cid})
+
+    async def send_stop(self) -> None:
+        await self.chan.send({'stop': True, 'cid': self.cid})
+
+
+def current_context():
+    """Get the current streaming task's context instance.
+
+    """
+    return _context.get()
+
+
+def stream(func):
+    """Mark an async function as a streaming routine.
+    """
+    func._tractor_stream_function = True
+    return func

--- a/tractor/msg.py
+++ b/tractor/msg.py
@@ -12,7 +12,7 @@ import wrapt
 
 from .log import get_logger
 from . import current_actor
-from ._ipc import Context
+from ._streaming import Context, stream
 
 __all__ = ['pub']
 
@@ -261,4 +261,4 @@ def pub(
             "`get_topics` argument"
         )
 
-    return wrapper(wrapped)
+    return wrapper(stream(wrapped))


### PR DESCRIPTION
Require explicitly decorated stream functions using `@tractor.stream` such that we can raise a `TypeError` on a missing `ctx` arg.

Still needs tests.
Reorged the streaming section in the docs.