### PR TITLE
More thorough basic supervision tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ An async-native "`actor model`_" built on trio_ and multiprocessing_.
 
 .. _actor model: https://en.wikipedia.org/wiki/Actor_model
 .. _trio: https://github.com/python-trio/trio
-.. _multiprocessing: https://docs.python.org/3/library/multiprocessing.html
+.. _multiprocessing: https://en.wikipedia.org/wiki/Multiprocessing
 .. _trionic: https://trio.readthedocs.io/en/latest/design.html#high-level-design-principles
 .. _async sandwich: https://trio.readthedocs.io/en/latest/tutorial.html#async-sandwich
 .. _always propagate: https://trio.readthedocs.io/en/latest/design.html#exceptions-always-propagate
@@ -21,17 +21,31 @@ An async-native "`actor model`_" built on trio_ and multiprocessing_.
 .. _chaos engineering: http://principlesofchaos.org/
 
 
-``tractor`` is an attempt to bring trionic_ `structured concurrency`_ to distributed multi-core Python.
+``tractor`` is an attempt to bring trionic_ `structured concurrency`_ to
+distributed multi-core Python.
 
-``tractor`` lets you spawn ``trio`` *"actors"*: processes which each run a ``trio`` scheduler and task
-tree (also known as an `async sandwich`_). *Actors* communicate by exchanging asynchronous messages_ over
-channels_ and avoid sharing any state.  This model allows for highly distributed software architecture
-which works just as well on multiple cores as it does over many hosts.
+``tractor`` lets you spawn ``trio`` *"actors"*: processes which each run
+a ``trio`` scheduled task tree (also known as an `async sandwich`_).
+*Actors* communicate by exchanging asynchronous messages_ and avoid
+sharing any state. This model allows for highly distributed software
+architecture which works just as well on multiple cores as it does over
+many hosts.
 
-``tractor`` is an actor-model-*like* system in the sense that it adheres to the `3 axioms`_ but does
-not (yet) fufill all "unrequirements_" in practice. The API and design takes inspiration from pulsar_ and
-execnet_ but attempts to be more focussed on sophistication of the lower level distributed architecture as
-well as have first class support for streaming using `async generators`_.
+``tractor`` is an actor-model-*like* system in the sense that it adheres
+to the `3 axioms`_ but does not (yet) fulfil all "unrequirements_" in
+practise. It is an experiment in applying `structured concurrency`_
+constraints on a parallel processing system where multiple Python
+processes exist over many hosts but no process can outlive its parent.
+In `erlang` parlance, it is an architecture where every process has
+a mandatory supervisor enforced by the type system. The API design is
+almost exclusively inspired by trio_'s concepts and primitives (though
+we often lag a little). As a distributed computing system `tractor`
+attempts to place sophistication at the correct layer such that
+concurrency primitives are powerful yet simple, making it easy to build
+complex systems (you can build a "worker pool" architecture but it's
+definitely not required). There is first class support for inter-actor
+streaming using `async generators`_ and ongoing work toward a functional
+reactive style for IPC.
 
 The first step to grok ``tractor`` is to get the basics of ``trio`` down.
 A great place to start is the `trio docs`_ and this `blog post`_.
@@ -56,7 +70,7 @@ Its tenets non-comprehensively include:
 
 - strict adherence to the `concept-in-progress`_ of *structured concurrency*
 - no spawning of processes *willy-nilly*; causality_ is paramount!
-- (remote) errors `always propagate`_ back to the parent / caller
+- (remote) errors `always propagate`_ back to the parent supervisor
 - verbatim support for ``trio``'s cancellation_ system
 - `shared nothing architecture`_
 - no use of *proxy* objects or shared references between processes

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     maintainer='Tyler Goodlet',
     maintainer_email='jgbt@protonmail.com',
     url='https://github.com/goodboy/tractor',
-    platforms=['linux'],
+    platforms=['linux', 'windows'],
     packages=[
         'tractor',
         'tractor.testing',
@@ -53,7 +53,8 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",
         "Topic :: System :: Distributed Computing",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,5 +35,7 @@ def pytest_generate_tests(metafunc):
         from multiprocessing import get_all_start_methods
         methods = get_all_start_methods()
         if 'fork' in methods:  # fork not available on windows, so check before removing
+            # XXX: the fork method is in general incompatible with
+            # trio's global scheduler state
             methods.remove('fork')
         metafunc.parametrize("start_method", methods, scope='module')

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -60,7 +60,7 @@ async def say_hello_use_wait(other_actor):
 
 @tractor_test
 @pytest.mark.parametrize('func', [say_hello, say_hello_use_wait])
-async def test_trynamic_trio(func):
+async def test_trynamic_trio(func, start_method):
     """Main tractor entry point, the "master" process (for now
     acts as the "director").
     """

--- a/tractor/_exceptions.py
+++ b/tractor/_exceptions.py
@@ -5,6 +5,8 @@ import importlib
 import builtins
 import traceback
 
+import trio
+
 
 _this_mod = importlib.import_module(__name__)
 
@@ -14,7 +16,7 @@ class RemoteActorError(Exception):
     "Remote actor exception bundled locally"
     def __init__(self, message, type_str, **msgdata):
         super().__init__(message)
-        for ns in [builtins, _this_mod]:
+        for ns in [builtins, _this_mod, trio]:
             try:
                 self.type = getattr(ns, type_str)
                 break


### PR DESCRIPTION
Attention all lurkers: code reviews and specifically criticisms are appreciated!

This is mostly to resolve #43 but I created some related issues (#87, #88, #89) after thinking and working through other types of failure cases we need to handle.

The main solution to get this working was adding proper `MultiError` propagation support in the core.

Interestingly writing the nested sub-actor error propagation tests actually found some serious holdups in the `multiprocessing` forkserver code. Even with my patches to the stdlib (which are pretty questionable) the server breaks pretty easily (causing hangs) when spawning any more then a couple "levels" (really lifetime scopes) of process tree. It's all good fodder for #84 and either writing our own forkserver or looking at the proper way to get the stdlib's version to play with our model. Surprisingly the *spawn* method works just fine so trying out [`trio_run_in_process`](https://github.com/ethereum/trio-run-in-process) has some more incentive; interested to see how it performs vs. the stdlib's version.