### PR TITLE
Log task and actor names where possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ install:
     - pip install -U . -r requirements-test.txt --upgrade-strategy eager
 
 script:
-    - mypy tractor/  --ignore-missing-imports
+    - mypy tractor/ --ignore-missing-imports
     - pytest tests/ --no-print-logs

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ pytest
 pytest-trio
 pdbpp
 mypy
+trio_typing

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
     ],
     install_requires=[
         'msgpack', 'trio>0.8', 'async_generator', 'colorlog', 'wrapt',
-        'trio_typing',
     ],
     tests_require=['pytest'],
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,9 @@ setup(
         'tractor.testing',
     ],
     install_requires=[
-        'msgpack', 'trio>0.8', 'async_generator', 'colorlog', 'wrapt'],
+        'msgpack', 'trio>0.8', 'async_generator', 'colorlog', 'wrapt',
+        'trio_typing',
+    ],
     tests_require=['pytest'],
     python_requires=">=3.7",
     keywords=[

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -4,7 +4,7 @@ tractor: An actor model micro-framework built on
 """
 import importlib
 from functools import partial
-from typing import Tuple, Any
+from typing import Tuple, Any, Optional
 import typing
 
 import trio  # type: ignore
@@ -47,8 +47,8 @@ async def _main(
     async_fn: typing.Callable[..., typing.Awaitable],
     args: Tuple,
     kwargs: typing.Dict[str, typing.Any],
-    name: str,
-    arbiter_addr: Tuple[str, int]
+    arbiter_addr: Tuple[str, int],
+    name: Optional[str] = None,
 ) -> typing.Any:
     """Async entry point for ``tractor``.
     """
@@ -89,26 +89,27 @@ async def _main(
     # for it to stay up indefinitely until a re-election process has
     # taken place - which is not implemented yet FYI).
     return await _start_actor(
-        actor, main, host, port, arbiter_addr=arbiter_addr)
+        actor, main, host, port, arbiter_addr=arbiter_addr
+    )
 
 
 def run(
     async_fn: typing.Callable[..., typing.Awaitable],
-    *args: Tuple,
-    name: str = None,
+    *args,
+    name: Optional[str] = None,
     arbiter_addr: Tuple[str, int] = (
         _default_arbiter_host, _default_arbiter_port),
     # the `multiprocessing` start method:
     # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
     start_method: str = 'forkserver',
-    **kwargs: typing.Dict[str, typing.Any],
+    **kwargs,
 ) -> Any:
     """Run a trio-actor async function in process.
 
     This is tractor's main entry and the start point for any async actor.
     """
     _spawn.try_set_start_method(start_method)
-    return trio.run(_main, async_fn, args, kwargs, name, arbiter_addr)
+    return trio.run(_main, async_fn, args, kwargs, arbiter_addr, name)
 
 
 def run_daemon(

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -445,8 +445,8 @@ class Actor:
                     # spin up a task for the requested function
                     log.debug(f"Spawning task for {func}")
                     cs = await self._root_nursery.start(
-                        _invoke, self, cid, chan, func, kwargs,
-                        name=funcname
+                        partial(_invoke, self, cid, chan, func, kwargs),
+                        name=funcname,
                     )
                     # never allow cancelling cancel requests (results in
                     # deadlock and other weird behaviour)
@@ -639,7 +639,7 @@ class Actor:
             # TODO: might want to consider having a separate nursery
             # for the stream handler such that the server can be cancelled
             # whilst leaving existing channels up
-            listeners = await nursery.start(
+            listeners: List[trio.abc.Listener] = await nursery.start(
                 partial(
                     trio.serve_tcp,
                     self._stream_handler,
@@ -650,7 +650,7 @@ class Actor:
                 )
             )
             log.debug(
-                f"Started tcp server(s) on {[l.socket for l in listeners]}")
+                    f"Started tcp server(s) on {[l.socket for l in listeners]}")  # type: ignore
             self._listeners.extend(listeners)
             task_status.started()
 

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -331,7 +331,7 @@ async def open_portal(
         if channel.uid is None:
             await actor._do_handshake(channel)
 
-        msg_loop_cs = await nursery.start(
+        msg_loop_cs: trio.CancelScope = await nursery.start(
             partial(
                 actor._process_messages,
                 channel,

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -21,7 +21,9 @@ log = get_logger('tractor')
 
 
 @asynccontextmanager
-async def maybe_open_nursery(nursery: trio._core._run.Nursery = None):
+async def maybe_open_nursery(
+    nursery: trio.Nursery = None
+) -> typing.AsyncGenerator[trio.Nursery, Any]:
     """Create a new nursery if None provided.
 
     Blocks on exit as expected if no input nursery is provided.
@@ -252,14 +254,14 @@ class Portal:
             for stream in self._streams.copy():
                 await stream.aclose()
 
-    async def aclose(self) -> None:
+    async def aclose(self):
         log.debug(f"Closing {self}")
         # TODO: once we move to implementing our own `ReceiveChannel`
         # (including remote task cancellation inside its `.aclose()`)
         # we'll need to .aclose all those channels here
         await self._cancel_streams()
 
-    async def cancel_actor(self) -> bool:
+    async def cancel_actor(self):
         """Cancel the actor on the other end of this portal.
         """
         if not self.channel.connected():
@@ -279,7 +281,9 @@ class Portal:
                 return True
             if cancel_scope.cancelled_caught:
                 log.warning(f"May have failed to cancel {self.channel.uid}")
-                return False
+
+            # if we get here some weird cancellation case happened
+            return False
         except trio.ClosedResourceError:
             log.warning(
                 f"{self.channel} for {self.channel.uid} was already closed?")
@@ -309,7 +313,7 @@ class LocalPortal:
 @asynccontextmanager
 async def open_portal(
     channel: Channel,
-    nursery: trio._core._run.Nursery = None
+    nursery: Optional[trio.Nursery] = None
 ) -> typing.AsyncGenerator[Portal, None]:
     """Open a ``Portal`` through the provided ``channel``.
 
@@ -320,7 +324,6 @@ async def open_portal(
     was_connected = False
 
     async with maybe_open_nursery(nursery) as nursery:
-
         if not channel.connected():
             await channel.connect()
             was_connected = True

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -21,7 +21,7 @@ from ._state import current_actor
 from ._actor import Actor
 
 
-_ctx: mp.context.BaseContext = mp.get_context("spawn")
+_ctx: mp.context.BaseContext = mp.get_context("spawn")  # type: ignore
 
 
 def try_set_start_method(name: str) -> mp.context.BaseContext:
@@ -95,7 +95,7 @@ def new_proc(
     else:
         fs_info = (None, None, None, None, None)
 
-    return _ctx.Process(
+    return _ctx.Process(  # type: ignore
         target=actor._fork_main,
         args=(
             bind_addr,

--- a/tractor/_state.py
+++ b/tractor/_state.py
@@ -3,6 +3,7 @@ Per process state
 """
 from typing import Optional
 
+import trio
 
 _current_actor: Optional['Actor'] = None  # type: ignore
 
@@ -10,6 +11,26 @@ _current_actor: Optional['Actor'] = None  # type: ignore
 def current_actor() -> 'Actor':  # type: ignore
     """Get the process-local actor instance.
     """
-    if not _current_actor:
-        raise RuntimeError("No actor instance has been defined yet?")
+    if _current_actor is None:
+        raise RuntimeError("No local actor has been initialized yet")
     return _current_actor
+
+
+class ActorContextInfo:
+    "Dyanmic lookup for local actor and task names"
+    def __iter__(self):
+        return iter(('task', 'actor'))
+
+    def __getitem__(self, key: str):
+        if key == 'task':
+            try:
+                return trio._core.current_task().name
+            except RuntimeError:
+                # not inside `trio.run()` yet
+                return 'no task context'
+        elif key == 'actor':
+            try:
+                return current_actor().name
+            except RuntimeError:
+                # no local actor initialize yet
+                return 'no actor context'

--- a/tractor/log.py
+++ b/tractor/log.py
@@ -48,7 +48,9 @@ BOLD_PALETTE = {
 }
 
 
-def get_logger(name: str = None) -> logging.Logger:
+def get_logger(
+    name: str = None
+) -> logging.LoggerAdapter:
     '''Return the package log or a sub-log for `name` if provided.
     '''
     log = rlog = logging.getLogger(_proj_name)
@@ -58,18 +60,21 @@ def get_logger(name: str = None) -> logging.Logger:
 
     # add our actor-task aware adapter which will dynamically look up
     # the actor and task names at each log emit
-    log = logging.LoggerAdapter(log, ActorContextInfo())
+    logger = logging.LoggerAdapter(log, ActorContextInfo())
 
     # additional levels
     for name, val in LEVELS.items():
         logging.addLevelName(val, name)
-        # ex. create ``log.trace()``
-        setattr(log, name.lower(), partial(log.log, val))
+        # ex. create ``logger.trace()``
+        setattr(logger, name.lower(), partial(logger.log, val))
 
-    return log
+    return logger
 
 
-def get_console_log(level: str = None, name: str = None) -> logging.Logger:
+def get_console_log(
+    level: str = None,
+    name: str = None
+) -> logging.LoggerAdapter:
     '''Get the package logger and enable a handler which writes to stderr.
 
     Yeah yeah, i know we can use ``DictConfig``. You do it.

--- a/tractor/log.py
+++ b/tractor/log.py
@@ -49,11 +49,12 @@ BOLD_PALETTE = {
 
 
 def get_logger(
-    name: str = None
+    name: str = None,
+    _root_name: str = _proj_name,
 ) -> logging.LoggerAdapter:
     '''Return the package log or a sub-log for `name` if provided.
     '''
-    log = rlog = logging.getLogger(_proj_name)
+    log = rlog = logging.getLogger(_root_name)
     if name and name != _proj_name:
         log = rlog.getChild(name)
         log.level = rlog.level
@@ -73,13 +74,13 @@ def get_logger(
 
 def get_console_log(
     level: str = None,
-    name: str = None
+    **kwargs,
 ) -> logging.LoggerAdapter:
     '''Get the package logger and enable a handler which writes to stderr.
 
     Yeah yeah, i know we can use ``DictConfig``. You do it.
     '''
-    log = get_logger(name)  # our root logger
+    log = get_logger(**kwargs)  # our root logger
     logger = log.logger
 
     if not level:


### PR DESCRIPTION
Prepend the actor and task names in each log emission. This makes
debugging much more sane since you can see from which process and
running task the log message originates from!

Resolves #13