### PR TITLE
Add script "guards" to docs examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,8 @@ the hip new film we're shooting:
             print("CUTTTT CUUTT CUT!!! Donny!! You're supposed to say...")
 
 
-    tractor.run(main)
+    if __name__ == '__main__':
+        tractor.run(main)
 
 
 We spawn two *actors*, *donny* and *gretchen*.
@@ -192,7 +193,9 @@ and use the ``run_in_actor()`` method:
 
         print(await portal.result())
 
-    tractor.run(main)
+
+    if __name__ == '__main__':
+        tractor.run(main)
 
 
 What's going on?


### PR DESCRIPTION
This was originally bundled in #102 but the windows CI there has blocked
that from landing quickly. These examples need to be fixed stat since
I've had at least a couple people notice it now when first trying out
the project.

Ping @salotz and @dxflores.