### PR TITLE
Infect `asyncio`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
   testing-linux:
     name: '${{ matrix.os }} Python ${{ matrix.python }} - ${{ matrix.spawn_backend }}'
-    timeout-minutes: 9
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -27,7 +27,9 @@ Features
 - A modular transport stack, allowing for custom serialization (eg.
   `msgspec`_), communications protocols, and environment specific IPC
   primitives
-- `structured concurrency`_ from the ground up
+- Support for spawning process-level-SC, inter-loop one-to-one-task oriented
+  ``asyncio`` actors via "infected ``asyncio``" mode
+- `structured chadcurrency`_ from the ground up
 
 
 Run a func in a process
@@ -588,7 +590,8 @@ channel`_!
 .. _messages: https://en.wikipedia.org/wiki/Message_passing
 .. _trio docs: https://trio.readthedocs.io/en/latest/
 .. _blog post: https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/
-.. _structured concurrency: https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/
+.. _structured concurrency: https://en.wikipedia.org/wiki/Structured_concurrency
+.. _structured chadcurrency: https://en.wikipedia.org/wiki/Structured_concurrency
 .. _unrequirements: https://en.wikipedia.org/wiki/Actor_model#Direct_communication_and_asynchrony
 .. _async generators: https://www.python.org/dev/peps/pep-0525/
 .. _trio-parallel: https://github.com/richardsheridan/trio-parallel

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -417,6 +417,12 @@ Yes, we spawn a python process, run ``asyncio``, start ``trio`` on the
 ``asyncio`` loop, then send commands to the ``trio`` scheduled tasks to
 tell ``asyncio`` tasks what to do XD
 
+We need help refining the `asyncio`-side channel API to be more
+`trio`-like. Feel free to sling your opinion in `#273`_!
+
+
+.. _#273: https://github.com/goodboy/tractor/issues/273
+
 
 Higher level "cluster" APIs
 ---------------------------
@@ -594,6 +600,7 @@ channel`_!
 .. _blog post: https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/
 .. _structured concurrency: https://en.wikipedia.org/wiki/Structured_concurrency
 .. _structured chadcurrency: https://en.wikipedia.org/wiki/Structured_concurrency
+.. _structured concurrency: https://en.wikipedia.org/wiki/Structured_concurrency
 .. _unrequirements: https://en.wikipedia.org/wiki/Actor_model#Direct_communication_and_asynchrony
 .. _async generators: https://www.python.org/dev/peps/pep-0525/
 .. _trio-parallel: https://github.com/richardsheridan/trio-parallel

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -347,6 +347,7 @@ Check out our experimental system for `guest-mode`_ controlled
         while True:
             # echo the msg back
             to_trio.send_nowait(await from_trio.get())
+            await asyncio.sleep(0)
 
 
     @tractor.context

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -583,6 +583,7 @@ channel`_!
 .. _async sandwich: https://trio.readthedocs.io/en/latest/tutorial.html#async-sandwich
 .. _structured concurrent: https://trio.discourse.group/t/concise-definition-of-structured-concurrency/228
 .. _3 axioms: https://www.youtube.com/watch?v=7erJ1DV_Tlo&t=162s
+.. .. _3 axioms: https://en.wikipedia.org/wiki/Actor_model#Fundamental_concepts
 .. _adherance to: https://www.youtube.com/watch?v=7erJ1DV_Tlo&t=1821s
 .. _trio gitter channel: https://gitter.im/python-trio/general
 .. _matrix channel: https://matrix.to/#/!tractor:matrix.org

--- a/examples/infected_asyncio_echo_server.py
+++ b/examples/infected_asyncio_echo_server.py
@@ -25,6 +25,7 @@ async def aio_echo_server(
     while True:
         # echo the msg back
         to_trio.send_nowait(await from_trio.get())
+        await asyncio.sleep(0)
 
 
 @tractor.context

--- a/examples/infected_asyncio_echo_server.py
+++ b/examples/infected_asyncio_echo_server.py
@@ -1,0 +1,90 @@
+'''
+An SC compliant infected ``asyncio`` echo server.
+
+'''
+import asyncio
+from statistics import mean
+import time
+
+import trio
+import tractor
+
+
+async def aio_echo_server(
+    to_trio: trio.MemorySendChannel,
+    from_trio: asyncio.Queue,
+) -> None:
+
+    # a first message must be sent **from** this ``asyncio``
+    # task or the ``trio`` side will never unblock from
+    # ``tractor.to_asyncio.open_channel_from():``
+    to_trio.send_nowait('start')
+
+    # XXX: this uses an ``from_trio: asyncio.Queue`` currently but we
+    # should probably offer something better.
+    while True:
+        # echo the msg back
+        to_trio.send_nowait(await from_trio.get())
+
+
+@tractor.context
+async def trio_to_aio_echo_server(
+    ctx: tractor.Context,
+):
+    # this will block until the ``asyncio`` task sends a "first"
+    # message.
+    async with tractor.to_asyncio.open_channel_from(
+        aio_echo_server,
+    ) as (first, chan):
+
+        assert first == 'start'
+        await ctx.started(first)
+
+        async with ctx.open_stream() as stream:
+
+            async for msg in stream:
+                await chan.send(msg)
+
+                out = await chan.receive()
+                # echo back to parent actor-task
+                await stream.send(out)
+
+
+async def main():
+
+    async with tractor.open_nursery() as n:
+        p = await n.start_actor(
+            'aio_server',
+            enable_modules=[__name__],
+            infect_asyncio=True,
+        )
+        async with p.open_context(
+            trio_to_aio_echo_server,
+        ) as (ctx, first):
+
+            assert first == 'start'
+
+            count = 0
+            async with ctx.open_stream() as stream:
+
+                delays = []
+                send = time.time()
+
+                await stream.send(count)
+                async for msg in stream:
+                    recv = time.time()
+                    delays.append(recv - send)
+                    assert msg == count
+                    count += 1
+                    send = time.time()
+                    await stream.send(count)
+
+                    if count >= 1e3:
+                        break
+
+        print(f'mean round trip rate (Hz): {1/mean(delays)}')
+        await p.cancel_actor()
+
+
+if __name__ == '__main__':
+    trio.run(main)

--- a/newsfragments/121.feature.rst
+++ b/newsfragments/121.feature.rst
@@ -1,0 +1,28 @@
+Add "infected ``asyncio`` mode; a sub-system to spawn and control
+``asyncio`` actors using ``trio``'s guest-mode.
+
+This gets us the following very interesting functionality:
+
+- ability to spawn an actor that has a process entry point of
+  ``asyncio.run()`` by passing ``infect_asyncio=True`` to
+  ``Portal.start_actor()`` (and friends).
+- the ``asyncio`` actor embeds ``trio`` using guest-mode and starts
+  a main ``trio`` task which runs the ``tractor.Actor._async_main()``
+  entry point engages all the normal ``tractor`` runtime IPC/messaging
+  machinery; for all purposes the actor is now running normally on
+  a ``trio.run()``.
+- the actor can now make one-to-one task spawning requests to the
+  underlying ``asyncio`` event loop using either of:
+  * ``to_asyncio.run_task()`` to spawn and run an ``asyncio`` task to
+    completion and block until a return value is delivered.
+  * ``async with to_asyncio.open_channel_from():`` which spawns a task
+    and hands it a pair of "memory channels" to allow for bi-directional
+    streaming between the now SC-linked ``trio`` and ``asyncio`` tasks.
+
+The output from any call(s) to ``asyncio`` can be handled as normal in
+``trio``/``tractor`` task operation with the caveat of the overhead due
+to guest-mode use.
+
+For more details see the `original PR
+<https://github.com/goodboy/tractor/pull/121>`_ and `issue
+<https://github.com/goodboy/tractor/issues/120>`_.

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -523,7 +523,7 @@ def test_fast_graceful_cancel_when_spawn_task_in_soft_proc_wait_for_daemon(
     cancellation, and it's faster, we might as well do it.
 
     '''
-    kbi_delay = 0.2
+    kbi_delay = 0.5
 
     async def main():
         start = time.time()

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -1,6 +1,7 @@
-"""
+'''
 Let's make sure them docs work yah?
-"""
+
+'''
 from contextlib import contextmanager
 import itertools
 import os

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -96,6 +96,31 @@ def test_tractor_cancels_aio(arb_addr):
     trio.run(main)
 
 
+def test_trio_cancels_aio(arb_addr):
+    '''
+    Much like the above test with ``tractor.Portal.cancel_actor()``
+    except we just use a standard ``trio`` cancellation api.
+
+    '''
+    async def main():
+
+        with trio.move_on_after(1):
+            # cancel the nursery shortly after boot
+
+            async with tractor.open_nursery() as n:
+                # debug_mode=True
+            # ) as n:
+                portal = await n.run_in_actor(
+                    asyncio_actor,
+                    target='sleep_forever',
+                    expect_err='trio.Cancelled',
+                    infect_asyncio=True,
+                )
+
+    trio.run(main)
+
+
+
 async def aio_cancel():
     ''''Cancel urself boi.
 
@@ -124,10 +149,6 @@ def test_aio_cancelled_from_aio_causes_trio_cancelled(arb_addr):
 
     with pytest.raises(RemoteActorError) as excinfo:
         trio.run(main)
-
-
-def test_trio_cancels_aio(arb_addr):
-    ...
 
 
 def test_trio_error_cancels_aio(arb_addr):

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -1,7 +1,12 @@
+'''
+The most hipster way to force SC onto the stdlib's "async".
+
+'''
 import asyncio
 
 import pytest
 import tractor
+
 
 async def sleep_and_err():
     await asyncio.sleep(0.1)
@@ -14,7 +19,7 @@ async def asyncio_actor():
     await tractor.to_asyncio.run_task(sleep_and_err)
 
 
-def test_infected_simple_error(arb_addr):
+def test_aio_simple_error(arb_addr):
 
     async def main():
         async with tractor.open_nursery() as n:
@@ -22,3 +27,35 @@ def test_infected_simple_error(arb_addr):
 
     with pytest.raises(tractor.RemoteActorError) as excinfo:
         tractor.run(main, arbiter_addr=arb_addr)
+
+
+def test_aio_cancel_from_trio(arb_addr):
+    ...
+
+
+def test_aio_cancelled_from_aio_causes_trio_cancelled(arb_addr):
+    ...
+
+
+def test_trio_cancels_aio(arb_addr):
+    ...
+
+
+def test_trio_error_cancels_aio(arb_addr):
+    ...
+
+
+def test_basic_interloop_channel_stream(arb_addr):
+    ...
+
+
+def test_basic_interloop_channel_stream(arb_addr):
+    ...
+
+
+def test_trio_cancels_and_channel_exits(arb_addr):
+    ...
+
+
+def test_aio_errors_and_channel_propagates(arb_addr):
+    ...

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -1,5 +1,5 @@
 '''
-The most hipster way to force SC onto the stdlib's "async".
+The hipster way to force SC onto the stdlib's "async": 'infection mode'.
 
 '''
 from typing import Optional, Iterable
@@ -74,7 +74,7 @@ async def asyncio_actor(
         if expect_err:
             assert isinstance(err, error_type)
 
-        raise err
+        raise
 
 
 def test_aio_simple_error(arb_addr):
@@ -134,7 +134,7 @@ def test_trio_cancels_aio(arb_addr):
             # cancel the nursery shortly after boot
 
             async with tractor.open_nursery() as n:
-                portal = await n.run_in_actor(
+                await n.run_in_actor(
                     asyncio_actor,
                     target='sleep_forever',
                     expect_err='trio.Cancelled',
@@ -144,9 +144,9 @@ def test_trio_cancels_aio(arb_addr):
     trio.run(main)
 
 
-
 async def aio_cancel():
-    ''''Cancel urself boi.
+    ''''
+    Cancel urself boi.
 
     '''
     await asyncio.sleep(0.5)
@@ -164,15 +164,15 @@ def test_aio_cancelled_from_aio_causes_trio_cancelled(arb_addr):
             portal = await n.run_in_actor(
                 asyncio_actor,
                 target='aio_cancel',
-                expect_err='asyncio.CancelledError',
+                expect_err='tractor.to_asyncio.AsyncioCancelled',
                 infect_asyncio=True,
             )
 
-            # with trio.CancelScope(shield=True):
-            await portal.result()
-
     with pytest.raises(RemoteActorError) as excinfo:
         trio.run(main)
+
+    # ensure boxed error is correct
+    assert excinfo.value.type == to_asyncio.AsyncioCancelled
 
 
 # TODO: verify open_channel_from will fail on this..
@@ -201,7 +201,7 @@ async def push_from_aio_task(
             if i == 50 and fail_early:
                 raise Exception
 
-        print(f'asyncio streamer complete!')
+        print('asyncio streamer complete!')
 
     except asyncio.CancelledError:
         if not expect_cancel:

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -2,7 +2,7 @@
 The most hipster way to force SC onto the stdlib's "async".
 
 '''
-from typing import Optional
+from typing import Optional, Iterable
 import asyncio
 import builtins
 import importlib
@@ -10,6 +10,7 @@ import importlib
 import pytest
 import trio
 import tractor
+from tractor import to_asyncio
 from tractor import RemoteActorError
 
 
@@ -176,17 +177,64 @@ def test_aio_cancelled_from_aio_causes_trio_cancelled(arb_addr):
         trio.run(main)
 
 
-def test_trio_error_cancels_aio(arb_addr):
-    ...
+# TODO:
+async def no_to_trio_in_args():
+    pass
+
+
+async def push_from_aio_task(
+
+    sequence: Iterable,
+    to_trio: trio.abc.SendChannel,
+
+) -> None:
+    for i in range(100):
+        print(f'asyncio sending {i}')
+        to_trio.send_nowait(i)
+        await asyncio.sleep(0.001)
+
+    print(f'asyncio streamer complete!')
+
+
+async def stream_from_aio():
+    seq = range(100)
+    expect = list(seq)
+
+    async with to_asyncio.open_channel_from(
+        push_from_aio_task,
+        sequence=seq,
+    ) as (first, chan):
+
+        pulled = [first]
+        async for value in chan:
+            print(f'trio received {value}')
+            pulled.append(value)
+
+        assert pulled == expect
+
+    print('trio guest mode task completed!')
 
 
 def test_basic_interloop_channel_stream(arb_addr):
-    ...
+    async def main():
+        async with tractor.open_nursery() as n:
+            portal = await n.run_in_actor(
+                stream_from_aio,
+                infect_asyncio=True,
+            )
+            await portal.result()
+
+    trio.run(main)
 
 
-def test_trio_cancels_and_channel_exits(arb_addr):
-    ...
+
+# def test_trio_error_cancels_intertask_chan(arb_addr):
+#     ...
 
 
-def test_aio_errors_and_channel_propagates(arb_addr):
-    ...
+# def test_trio_cancels_and_channel_exits(arb_addr):
+#     ...
+
+
+# def test_aio_errors_and_channel_propagates(arb_addr):
+#     ...

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -2,10 +2,15 @@
 The most hipster way to force SC onto the stdlib's "async".
 
 '''
+from typing import Optional
 import asyncio
+import builtins
+import importlib
 
 import pytest
+import trio
 import tractor
+from tractor import RemoteActorError
 
 
 async def sleep_and_err():
@@ -13,24 +18,78 @@ async def sleep_and_err():
     assert 0
 
 
-async def asyncio_actor():
-    assert tractor.current_actor().is_infected_aio()
+async def sleep_forever():
+    await asyncio.sleep(float('inf'))
 
-    await tractor.to_asyncio.run_task(sleep_and_err)
+
+async def asyncio_actor(
+
+    target: str,
+    expect_err: Optional[Exception] = None
+
+) -> None:
+
+    assert tractor.current_actor().is_infected_aio()
+    target = globals()[target]
+
+    if '.' in expect_err:
+        modpath, _, name = expect_err.rpartition('.')
+        mod = importlib.import_module(modpath)
+        error = getattr(mod, name)
+    error = builtins.__dict__.get(expect_err)
+
+    try:
+        # spawn an ``asyncio`` task to run a func and return result
+        await tractor.to_asyncio.run_task(target)
+    except Exception as err:
+        if expect_err:
+            assert isinstance(err, error)
+
+        raise
 
 
 def test_aio_simple_error(arb_addr):
+    '''
+    Verify a simple remote asyncio error propagates back through trio
+    to the parent actor.
 
+
+    '''
+    async def main():
+        async with tractor.open_nursery(
+            arbiter_addr=arb_addr
+        ) as n:
+            await n.run_in_actor(
+                asyncio_actor,
+                target='sleep_and_err',
+                expect_err='AssertionError',
+                infect_asyncio=True,
+            )
+
+    with pytest.raises(RemoteActorError) as excinfo:
+        trio.run(main)
+
+    err = excinfo.value
+    assert isinstance(err, RemoteActorError)
+    assert err.type == AssertionError
+
+
+def test_tractor_cancels_aio(arb_addr):
+    '''
+    Verify we can cancel a spawned asyncio task gracefully.
+
+    '''
     async def main():
         async with tractor.open_nursery() as n:
-            await n.run_in_actor(asyncio_actor, infected_asyncio=True)
+            portal = await n.run_in_actor(
+                asyncio_actor,
+                target='sleep_forever',
+                expect_err='asyncio.CancelledError',
+                infect_asyncio=True,
+            )
+            await portal.cancel_actor()
 
-    with pytest.raises(tractor.RemoteActorError) as excinfo:
-        tractor.run(main, arbiter_addr=arb_addr)
-
-
-def test_aio_cancel_from_trio(arb_addr):
-    ...
+    trio.run(main)
 
 
 def test_aio_cancelled_from_aio_causes_trio_cancelled(arb_addr):
@@ -42,10 +101,6 @@ def test_trio_cancels_aio(arb_addr):
 
 
 def test_trio_error_cancels_aio(arb_addr):
-    ...
-
-
-def test_basic_interloop_channel_stream(arb_addr):
     ...
 
 

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -1,0 +1,24 @@
+import asyncio
+
+import pytest
+import tractor
+
+async def sleep_and_err():
+    await asyncio.sleep(0.1)
+    assert 0
+
+
+async def asyncio_actor():
+    assert tractor.current_actor().is_infected_aio()
+
+    await tractor.to_asyncio.run_task(sleep_and_err)
+
+
+def test_infected_simple_error(arb_addr):
+
+    async def main():
+        async with tractor.open_nursery() as n:
+            await n.run_in_actor(asyncio_actor, infected_asyncio=True)
+
+    with pytest.raises(tractor.RemoteActorError) as excinfo:
+        tractor.run(main, arbiter_addr=arb_addr)

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -475,6 +475,7 @@ class Actor:
                 self._mods[modpath] = mod
                 if modpath == '__main__':
                     self._mods['__mp_main__'] = mod
+
         except ModuleNotFoundError:
             # it is expected the corresponding `ModuleNotExposed` error
             # will be raised later

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -361,6 +361,9 @@ class Actor:
     # syncs for setup/teardown sequences
     _server_down: Optional[trio.Event] = None
 
+    # if started on ``asycio`` running ``trio`` in guest mode
+    _infected_aio: bool = False
+
     def __init__(
         self,
         name: str,
@@ -1458,6 +1461,9 @@ class Actor:
         chan.uid = str(uid[0]), str(uid[1])
         log.runtime(f"Handshake with actor {uid}@{chan.raddr} complete")
         return uid
+
+    def is_infected_aio(self) -> bool:
+        return self._infected_aio
 
 
 class Arbiter(Actor):

--- a/tractor/_child.py
+++ b/tractor/_child.py
@@ -37,12 +37,15 @@ def parse_ipaddr(arg):
     return (str(host), int(port))
 
 
+from ._entry import _trio_main
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--uid", type=parse_uid)
     parser.add_argument("--loglevel", type=str)
     parser.add_argument("--parent_addr", type=parse_ipaddr)
+    parser.add_argument("--asyncio", action='store_true')
     args = parser.parse_args()
 
     subactor = Actor(
@@ -54,5 +57,6 @@ if __name__ == "__main__":
 
     _trio_main(
         subactor,
-        parent_addr=args.parent_addr
+        parent_addr=args.parent_addr,
+        infect_asyncio=args.asyncio,
     )

--- a/tractor/_entry.py
+++ b/tractor/_entry.py
@@ -33,15 +33,19 @@ log = get_logger(__name__)
 
 
 def _mp_main(
+
     actor: 'Actor',  # type: ignore
     accept_addr: Tuple[str, int],
     forkserver_info: Tuple[Any, Any, Any, Any, Any],
     start_method: str,
     parent_addr: Tuple[str, int] = None,
     infect_asyncio: bool = False,
+
 ) -> None:
-    """The routine called *after fork* which invokes a fresh ``trio.run``
-    """
+    '''
+    The routine called *after fork* which invokes a fresh ``trio.run``
+
+    '''
     actor._forkserver_info = forkserver_info
     from ._spawn import try_set_start_method
     spawn_ctx = try_set_start_method(start_method)
@@ -77,19 +81,17 @@ def _mp_main(
 
 
 def _trio_main(
+
     actor: 'Actor',  # type: ignore
     *,
     parent_addr: Tuple[str, int] = None,
     infect_asyncio: bool = False,
+
 ) -> None:
-    """Entry point for a `trio_run_in_process` subactor.
-    """
-    # Disable sigint handling in children;
-    # we don't need it thanks to our cancellation machinery.
-    # signal.signal(signal.SIGINT, signal.SIG_IGN)
+    '''
+    Entry point for a `trio_run_in_process` subactor.
 
-    log.info(f"Started new trio process for {actor.uid}")
-
+    '''
     log.info(f"Started new trio process for {actor.uid}")
 
     if actor.loglevel is not None:

--- a/tractor/_entry.py
+++ b/tractor/_entry.py
@@ -38,6 +38,7 @@ def _mp_main(
     forkserver_info: Tuple[Any, Any, Any, Any, Any],
     start_method: str,
     parent_addr: Tuple[str, int] = None,
+    infect_asyncio: bool = False,
 ) -> None:
     """The routine called *after fork* which invokes a fresh ``trio.run``
     """
@@ -79,12 +80,15 @@ def _trio_main(
     actor: 'Actor',  # type: ignore
     *,
     parent_addr: Tuple[str, int] = None,
+    infect_asyncio: bool = False,
 ) -> None:
     """Entry point for a `trio_run_in_process` subactor.
     """
     # Disable sigint handling in children;
     # we don't need it thanks to our cancellation machinery.
     # signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    log.info(f"Started new trio process for {actor.uid}")
 
     log.info(f"Started new trio process for {actor.uid}")
 
@@ -105,7 +109,11 @@ def _trio_main(
     )
 
     try:
-        trio.run(trio_main)
+        if infect_asyncio:
+            actor._infected_aio = True
+            run_as_asyncio_guest(trio_main)
+        else:
+            trio.run(trio_main)
     except KeyboardInterrupt:
         log.warning(f"Actor {actor.uid} received KBI")
 

--- a/tractor/_entry.py
+++ b/tractor/_entry.py
@@ -26,6 +26,7 @@ import trio  # type: ignore
 
 from .log import get_console_log, get_logger
 from . import _state
+from .to_asyncio import run_as_asyncio_guest
 
 
 log = get_logger(__name__)
@@ -62,7 +63,11 @@ def _mp_main(
         parent_addr=parent_addr
     )
     try:
-        trio.run(trio_main)
+        if infect_asyncio:
+            actor._infected_aio = True
+            run_as_asyncio_guest(trio_main)
+        else:
+            trio.run(trio_main)
     except KeyboardInterrupt:
         pass  # handle it the same way trio does?
 

--- a/tractor/_exceptions.py
+++ b/tractor/_exceptions.py
@@ -82,6 +82,15 @@ class StreamOverrun(trio.TooSlowError):
     "This stream was overrun by sender"
 
 
+class AsyncioCancelled(Exception):
+    '''
+    Asyncio cancelled translation (non-base) error
+    for use with the ``to_asyncio`` module
+    to be raised in the ``trio`` side task
+
+    '''
+
+
 def pack_error(
     exc: BaseException,
     tb=None,

--- a/tractor/_root.py
+++ b/tractor/_root.py
@@ -103,7 +103,6 @@ async def open_root_actor(
         _default_arbiter_port,
     )
 
-
     if loglevel is None:
         loglevel = log.get_loglevel()
     else:

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -244,6 +244,7 @@ async def new_proc(
     _runtime_vars: Dict[str, Any],  # serialized and sent to _child
 
     *,
+
     infect_asyncio: bool = False,
     task_status: TaskStatus[Portal] = trio.TASK_STATUS_IGNORED
 
@@ -415,6 +416,7 @@ async def new_proc(
             bind_addr=bind_addr,
             parent_addr=parent_addr,
             _runtime_vars=_runtime_vars,
+            infect_asyncio=infect_asyncio,
             task_status=task_status,
         )
 
@@ -430,6 +432,7 @@ async def mp_new_proc(
     parent_addr: Tuple[str, int],
     _runtime_vars: Dict[str, Any],  # serialized and sent to _child
     *,
+    infect_asyncio: bool = False,
     task_status: TaskStatus[Portal] = trio.TASK_STATUS_IGNORED
 
 ) -> None:
@@ -475,6 +478,7 @@ async def mp_new_proc(
             fs_info,
             start_method,
             parent_addr,
+            infect_asyncio,
         ),
         # daemon=True,
         name=name,

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -244,6 +244,7 @@ async def new_proc(
     _runtime_vars: Dict[str, Any],  # serialized and sent to _child
 
     *,
+    infect_asyncio: bool = False,
     task_status: TaskStatus[Portal] = trio.TASK_STATUS_IGNORED
 
 ) -> None:
@@ -260,7 +261,6 @@ async def new_proc(
     uid = subactor.uid
 
     if _spawn_method == 'trio':
-
         spawn_cmd = [
             sys.executable,
             "-m",
@@ -283,6 +283,9 @@ async def new_proc(
                 "--loglevel",
                 subactor.loglevel
             ]
+        # Tell child to run in guest mode on top of ``asyncio`` loop
+        if infect_asyncio:
+            spawn_cmd.append("--asyncio")
 
         cancelled_during_spawn: bool = False
         proc: Optional[trio.Process] = None

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -22,10 +22,10 @@ import sys
 import multiprocessing as mp
 import platform
 from typing import (
-    Any, Dict, Optional, Union, Callable,
+    Any, Dict, Optional, Callable,
     TypeVar,
 )
-from collections.abc import Awaitable, Coroutine
+from collections.abc import Awaitable
 
 import trio
 from trio_typing import TaskStatus

--- a/tractor/_supervise.py
+++ b/tractor/_supervise.py
@@ -81,6 +81,7 @@ class ActorNursery:
         loglevel: str = None,  # set log level per subactor
         nursery: trio.Nursery = None,
         debug_mode: Optional[bool] = None,
+        infect_asyncio: bool = False,
     ) -> Portal:
         '''
         Start a (daemon) actor: an process that has no designated
@@ -134,6 +135,7 @@ class ActorNursery:
                 bind_addr,
                 parent_addr,
                 _rtv,  # run time vars
+                infect_asyncio=infect_asyncio,
             )
         )
 
@@ -146,6 +148,7 @@ class ActorNursery:
         rpc_module_paths: Optional[List[str]] = None,
         enable_modules: List[str] = None,
         loglevel: str = None,  # set log level per subactor
+        infect_asyncio: bool = False,
         **kwargs,  # explicit args to ``fn``
     ) -> Portal:
         """Spawn a new actor, run a lone task, then terminate the actor and
@@ -170,6 +173,7 @@ class ActorNursery:
             loglevel=loglevel,
             # use the run_in_actor nursery
             nursery=self._ria_nursery,
+            infect_asyncio=infect_asyncio,
         )
 
         # XXX: don't allow stream funcs

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -94,6 +94,8 @@ async def run_task(
         """
         nonlocal err
         err = task.exception()
+        if err:
+            log.exception(f"asyncio task errorred:\n{err}")
         cancel_scope.cancel()
 
     task.add_done_callback(cancel_trio)
@@ -114,11 +116,13 @@ async def run_task(
 
     # simple async func
     elif inspect.iscoroutine(coro):
+
         with cancel_scope:
             # return single value
             return await from_aio.receive()
         if cancel_scope.cancelled_caught and err:
             raise err
+
 
 
 def run_as_asyncio_guest(

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -24,33 +24,19 @@ log = get_logger(__name__)
 __all__ = ['run_task', 'run_as_asyncio_guest']
 
 
-# async def consume_asyncgen(
-#     to_trio: trio.MemorySendChannel,
-#     coro: AsyncIterator,
-# ) -> None:
-#     """Stream async generator results back to ``trio``.
-
-#     ``from_trio`` might eventually be used here for
-#     bidirectional streaming.
-#     """
-#     async for item in coro:
-#         to_trio.send_nowait(item)
-
-
 def _run_asyncio_task(
     func: Callable,
     *,
     qsize: int = 1,
-    # _treat_as_stream: bool = False,
     provide_channels: bool = False,
     **kwargs,
 
 ) -> Any:
-    """
+    '''
     Run an ``asyncio`` async function or generator in a task, return
     or stream the result back to ``trio``.
 
-    """
+    '''
     if not current_actor().is_infected_aio():
         raise RuntimeError("`infect_asyncio` mode is not enabled!?")
 
@@ -66,7 +52,6 @@ def _run_asyncio_task(
         # the assumption is that the target async routine accepts the
         # send channel then it intends to yield more then one return
         # value otherwise it would just return ;P
-        # _treat_as_stream = True
         assert qsize > 1
 
     if provide_channels:
@@ -91,10 +76,10 @@ def _run_asyncio_task(
         aio_task_complete: trio.Event,
 
     ) -> None:
-        """
+        '''
         Await ``coro`` and relay result back to ``trio``.
 
-        """
+        '''
         nonlocal aio_err
         orig = result = id(coro)
         try:
@@ -113,9 +98,6 @@ def _run_asyncio_task(
         task = asyncio.create_task(
             wait_on_coro_final_result(to_trio, coro, aio_task_complete)
         )
-
-    # elif inspect.isasyncgen(coro):
-    #     task = asyncio.create_task(consume_asyncgen(to_trio, coro))
 
     else:
         raise TypeError(f"No support for invoking {coro}")
@@ -147,7 +129,6 @@ async def run_task(
     *,
 
     qsize: int = 2**10,
-    # _treat_as_stream: bool = False,
     **kwargs,
 
 ) -> Any:
@@ -184,28 +165,19 @@ async def run_task(
             raise err from aio_err
         else:
             raise
-
-    # except trio.Cancelled:
-        # raise
     finally:
         if not task.done():
             task.cancel()
 
 
-# TODO: explicit api for the streaming case where
+# TODO: explicitly api for the streaming case where
 # we pull from the mem chan in an async generator?
 # This ends up looking more like our ``Portal.open_stream_from()``
 # NB: code below is untested.
 
-# async def _start_and_sync_aio_task(
-#     from_trio,
-#     to_trio,
-#     from_aio,
-
 
 @acm
 async def open_channel_from(
-
     target: Callable[[Any, ...], Any],
     **kwargs,
 
@@ -250,7 +222,8 @@ async def open_channel_from(
 def run_as_asyncio_guest(
     trio_main: Callable,
 ) -> None:
-    """Entry for an "infected ``asyncio`` actor".
+    '''
+    Entry for an "infected ``asyncio`` actor".
 
     Uh, oh. :o
 
@@ -265,8 +238,8 @@ def run_as_asyncio_guest(
 
     :)
 
-    """
-    # Disable sigint handling in children?
+    '''
+    # Disable sigint handling in children? (nawp)
     # import signal
     # signal.signal(signal.SIGINT, signal.SIG_IGN)
 

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -1,0 +1,150 @@
+"""
+Infection apis for ``asyncio`` loops running ``trio`` using guest mode.
+"""
+import asyncio
+import inspect
+from typing import (
+    Any,
+    Callable,
+    AsyncGenerator,
+    Awaitable,
+    Union,
+)
+
+import trio
+
+from .log import get_logger
+from ._state import current_actor
+
+log = get_logger(__name__)
+
+
+__all__ = ['run_task']
+
+
+async def _invoke(
+    from_trio: trio.abc.ReceiveChannel,
+    to_trio: asyncio.Queue,
+    coro: Awaitable,
+) -> Union[AsyncGenerator, Awaitable]:
+    """Await or stream awaiable object based on type into
+    ``trio`` memory channel.
+    """
+    async def stream_from_gen(c):
+        async for item in c:
+            to_trio.send_nowait(item)
+
+    async def just_return(c):
+        to_trio.send_nowait(await c)
+
+    if inspect.isasyncgen(coro):
+        return await stream_from_gen(coro)
+    elif inspect.iscoroutine(coro):
+        return await coro
+
+
+async def run_task(
+    func: Callable,
+    qsize: int = 2**10,
+    **kwargs,
+) -> Any:
+    """Run an ``asyncio`` async function or generator in a task, return
+    or stream the result back to ``trio``.
+    """
+    assert current_actor()._infected_aio
+
+    # ITC (inter task comms)
+    from_trio = asyncio.Queue(qsize)
+    to_trio, from_aio = trio.open_memory_channel(qsize)
+
+    # allow target func to accept/stream results manually
+    kwargs['to_trio'] = to_trio
+    kwargs['from_trio'] = to_trio
+
+    coro = func(**kwargs)
+
+    cancel_scope = trio.CancelScope()
+
+    # start the asyncio task we submitted from trio
+    # TODO: try out ``anyio`` asyncio based tg here
+    task = asyncio.create_task(_invoke(from_trio, to_trio, coro))
+    err = None
+
+    # XXX: I'm not sure this actually does anything...
+    def cancel_trio(task):
+        """Cancel the calling ``trio`` task on error.
+        """
+        nonlocal err
+        err = task.exception()
+        cancel_scope.cancel()
+
+    task.add_done_callback(cancel_trio)
+
+    # determine return type async func vs. gen
+    if inspect.isasyncgen(coro):
+        # simple async func
+        async def result():
+            with cancel_scope:
+                return await from_aio.get()
+            if cancel_scope.cancelled_caught and err:
+                raise err
+
+    elif inspect.iscoroutine(coro):
+        # asycn gen
+        async def result():
+            with cancel_scope:
+                async with from_aio:
+                    async for item in from_aio:
+                        yield item
+            if cancel_scope.cancelled_caught and err:
+                raise err
+
+    return result()
+
+
+def run_as_asyncio_guest(
+    trio_main: Awaitable,
+) -> None:
+    """Entry for an "infected ``asyncio`` actor".
+
+    Uh, oh. :o
+
+    It looks like your event loop has caught a case of the ``trio``s.
+
+    :()
+
+    Don't worry, we've heard you'll barely notice. You might hallucinate
+    a few more propagating errors and feel like your digestion has
+    slowed but if anything get's too bad your parents will know about
+    it.
+
+    :)
+    """
+    async def aio_main(trio_main):
+        loop = asyncio.get_running_loop()
+
+        trio_done_fut = asyncio.Future()
+
+        def trio_done_callback(main_outcome):
+            log.info(f"trio_main finished: {main_outcome!r}")
+            trio_done_fut.set_result(main_outcome)
+
+        # start the infection: run trio on the asyncio loop in "guest mode"
+        log.info(f"Infecting asyncio process with {trio_main}")
+        trio.lowlevel.start_guest_run(
+            trio_main,
+            run_sync_soon_threadsafe=loop.call_soon_threadsafe,
+            done_callback=trio_done_callback,
+        )
+
+        (await trio_done_fut).unwrap()
+
+    # might as well if it's installed.
+    try:
+        import uvloop
+        loop = uvloop.new_event_loop()
+        asyncio.set_event_loop(loop)
+    except ImportError:
+        pass
+
+    asyncio.run(aio_main(trio_main))

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -102,6 +102,7 @@ def _run_asyncio_task(
         except BaseException as err:
             aio_err = err
             from_aio._err = aio_err
+            raise
         finally:
             aio_task_complete.set()
             if result != orig and aio_err is None:
@@ -119,9 +120,11 @@ def _run_asyncio_task(
     else:
         raise TypeError(f"No support for invoking {coro}")
 
-    def cancel_trio(task):
-        """Cancel the calling ``trio`` task on error.
-        """
+    def cancel_trio(task) -> None:
+        '''
+        Cancel the calling ``trio`` task on error.
+
+        '''
         nonlocal aio_err
         try:
             aio_err = task.exception()

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -136,6 +136,13 @@ def _run_asyncio_task(
         nonlocal aio_err
         aio_err = from_aio._err
 
+        # only to avoid ``asyncio`` complaining about uncaptured
+        # task exceptions
+        try:
+            task.exception()
+        except BaseException as terr:
+            assert type(terr) is type(aio_err), 'Asyncio task error mismatch?'
+
         if aio_err is not None:
             if type(aio_err) is CancelledError:
                 log.cancel("infected task was cancelled")

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -1,3 +1,19 @@
+# tractor: structured concurrent "actors".
+# Copyright 2018-eternity Tyler Goodlet.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 '''
 Infection apis for ``asyncio`` loops running ``trio`` using guest mode.
 

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -164,16 +164,19 @@ def run_as_asyncio_guest(
     :)
     """
     async def aio_main(trio_main):
+
         loop = asyncio.get_running_loop()
 
         trio_done_fut = asyncio.Future()
 
         def trio_done_callback(main_outcome):
+
             log.info(f"trio_main finished: {main_outcome!r}")
             trio_done_fut.set_result(main_outcome)
 
         # start the infection: run trio on the asyncio loop in "guest mode"
         log.info(f"Infecting asyncio process with {trio_main}")
+
         trio.lowlevel.start_guest_run(
             trio_main,
             run_sync_soon_threadsafe=loop.call_soon_threadsafe,

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -55,7 +55,8 @@ def _run_asyncio_task(
     or stream the result back to ``trio``.
 
     """
-    assert current_actor().is_infected_aio()
+    if not current_actor().is_infected_aio():
+        raise RuntimeError("`infect_asyncio` mode is not enabled!?")
 
     # ITC (inter task comms)
     from_trio = asyncio.Queue(qsize)  # type: ignore
@@ -174,11 +175,11 @@ async def run_task(
         else:
             raise
 
-    except trio.Cancelled:
-        if not task.done():
-            task.cancel()
-
-        raise
+    # except trio.Cancelled:
+        # raise
+    finally:
+        # if not task.done():
+        task.cancel()
 
 
 # TODO: explicit api for the streaming case where

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -5,6 +5,7 @@ Infection apis for ``asyncio`` loops running ``trio`` using guest mode.
 import asyncio
 from asyncio.exceptions import CancelledError
 from contextlib import asynccontextmanager as acm
+from dataclasses import dataclass
 import inspect
 from typing import (
     Any,
@@ -41,7 +42,8 @@ def _run_asyncio_task(
     if not current_actor().is_infected_aio():
         raise RuntimeError("`infect_asyncio` mode is not enabled!?")
 
-    # ITC (inter task comms)
+    # ITC (inter task comms), these channel/queue names are mostly from
+    # ``asyncio``'s perspective.
     from_trio = asyncio.Queue(qsize)  # type: ignore
     to_trio, from_aio = trio.open_memory_channel(qsize)  # type: ignore
 
@@ -89,6 +91,8 @@ def _run_asyncio_task(
         except BaseException as err:
             aio_err = err
             from_aio._err = aio_err
+            to_trio.close()
+            from_aio.close()
             raise
 
         finally:
@@ -102,8 +106,12 @@ def _run_asyncio_task(
             ):
                 to_trio.send_nowait(result)
 
-            to_trio.close()
-            from_aio.close()
+            # if the task was spawned using ``open_channel_from()``
+            # then we close the channels on exit.
+            if provide_channels:
+                to_trio.close()
+                from_aio.close()
+
             aio_task_complete.set()
 
     # start the asyncio task we submitted from trio
@@ -134,15 +142,17 @@ def _run_asyncio_task(
             cancel_scope.cancel()
         else:
             if aio_err is not None:
+                aio_err.with_traceback(aio_err.__traceback__)
                 log.exception("infected task errorred:")
                 from_aio._err = aio_err
-                # order is opposite here
+
+                # NOTE: order is opposite here
                 cancel_scope.cancel()
                 from_aio.close()
 
     task.add_done_callback(cancel_trio)
 
-    return task, from_aio, to_trio, cancel_scope, aio_task_complete
+    return task, from_aio, to_trio, from_trio, cancel_scope, aio_task_complete
 
 
 @acm
@@ -157,28 +167,32 @@ async def translate_aio_errors(
     appropriately translates errors and cancels into ``trio`` land.
 
     '''
+    err: Optional[Exception] = None
+    aio_err: Optional[Exception] = None
+
+    def maybe_raise_aio_err(err: Exception):
+        aio_err = from_aio._err
+        if (
+            aio_err is not None and
+            type(aio_err) != CancelledError
+        ):
+            # always raise from any captured asyncio error
+            raise aio_err from err
+
     try:
         yield
     except (
         Exception,
         CancelledError,
     ) as err:
-
-        aio_err = from_aio._err
-
-        if (
-            aio_err is not None and
-            type(aio_err) != CancelledError
-        ):
-            # always raise from any captured asyncio error
-            raise err from aio_err
-        else:
-            raise
+        maybe_raise_aio_err(err)
+        raise
 
     finally:
-        if not task.done():
+        if not task.done() and aio_err:
             task.cancel()
 
+        maybe_raise_aio_err(err)
         # if task.cancelled():
         #     ... do what ..
 
@@ -197,7 +211,7 @@ async def run_task(
 
     '''
     # simple async func
-    task, from_aio, to_trio, cs, _ = _run_asyncio_task(
+    task, from_aio, to_trio, aio_q, cs, _ = _run_asyncio_task(
         func,
         qsize=1,
         **kwargs,
@@ -224,28 +238,70 @@ async def run_task(
 # NB: code below is untested.
 
 
+@dataclass
+class LinkedTaskChannel(trio.abc.Channel):
+    '''
+    A "linked task channel" which allows for two-way synchronized msg
+    passing between a ``trio``-in-guest-mode task and an ``asyncio``
+    task.
+
+    '''
+    _aio_task: asyncio.Task
+    _to_aio: asyncio.Queue
+    _from_aio: trio.MemoryReceiveChannel
+    _aio_task_complete: trio.Event
+
+    async def aclose(self) -> None:
+        self._from_aio.close()
+
+    async def receive(self) -> Any:
+        async with translate_aio_errors(self._from_aio, self._aio_task):
+            return await self._from_aio.receive()
+
+    async def wait_ayncio_complete(self) -> None:
+        await self._aio_task_complete.wait()
+
+    def cancel_asyncio_task(self) -> None:
+        self._aio_task.cancel()
+
+    async def send(self, item: Any) -> None:
+        '''
+        Send a value through to the asyncio task presuming
+        it defines a ``from_trio`` argument, if it does not
+        this method will raise an error.
+
+        '''
+        self._to_aio.put_nowait(item)
+
+
 @acm
 async def open_channel_from(
+
     target: Callable[[Any, ...], Any],
     **kwargs,
 
 ) -> AsyncIterator[Any]:
+    '''
+    Open an inter-loop linked task channel for streaming between a target
+    spawned ``asyncio`` task and ``trio``.
 
-    task, from_aio, to_trio, cs, aio_task_complete = _run_asyncio_task(
+    '''
+    task, from_aio, to_trio, aio_q, cs, aio_task_complete = _run_asyncio_task(
         target,
         qsize=2**8,
         provide_channels=True,
         **kwargs,
     )
-    async with translate_aio_errors(from_aio, task):
-        with cs:
-            # sync to "started()" call.
+    chan = LinkedTaskChannel(task, aio_q, from_aio, aio_task_complete)
+    with cs:
+        async with translate_aio_errors(from_aio, task):
+            # sync to a "started()"-like first delivered value from the
+            # ``asyncio`` task.
             first = await from_aio.receive()
 
             # stream values upward
             async with from_aio:
-                yield first, from_aio
-                await aio_task_complete.wait()
+                yield first, chan
 
 
 def run_as_asyncio_guest(

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -247,23 +247,24 @@ def run_as_asyncio_guest(
     '''
     Entry for an "infected ``asyncio`` actor".
 
-    Uh, oh. :o
-
-    It looks like your event loop has caught a case of the ``trio``s.
-
-    :()
-
-    Don't worry, we've heard you'll barely notice. You might hallucinate
-    a few more propagating errors and feel like your digestion has
-    slowed but if anything get's too bad your parents will know about
-    it.
-
-    :)
+    Entrypoint for a Python process which starts the ``asyncio`` event
+    loop and runs ``trio`` in guest mode resulting in a system where
+    ``trio`` tasks can control ``asyncio`` tasks whilst maintaining
+    SC semantics.
 
     '''
-    # Disable sigint handling in children? (nawp)
-    # import signal
-    # signal.signal(signal.SIGINT, signal.SIG_IGN)
+    # Uh, oh. :o
+
+    # It looks like your event loop has caught a case of the ``trio``s.
+
+    # :()
+
+    # Don't worry, we've heard you'll barely notice. You might hallucinate
+    # a few more propagating errors and feel like your digestion has
+    # slowed but if anything get's too bad your parents will know about
+    # it.
+
+    # :)
 
     async def aio_main(trio_main):
 

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -111,7 +111,6 @@ def _run_asyncio_task(
 
         # cancel_scope.cancel()
         from_aio._err = aio_err
-        to_trio.close()
 
     task.add_done_callback(cancel_trio)
 

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -220,7 +220,9 @@ async def open_channel_from(
 
 
 def run_as_asyncio_guest(
+
     trio_main: Callable,
+
 ) -> None:
     '''
     Entry for an "infected ``asyncio`` actor".
@@ -242,8 +244,6 @@ def run_as_asyncio_guest(
     # Disable sigint handling in children? (nawp)
     # import signal
     # signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-    get_console_log('runtime')
 
     async def aio_main(trio_main):
 
@@ -273,4 +273,4 @@ def run_as_asyncio_guest(
     except ImportError:
         pass
 
-    asyncio.run(aio_main(trio_main))
+    return asyncio.run(aio_main(trio_main))

--- a/tractor/trionics/_broadcast.py
+++ b/tractor/trionics/_broadcast.py
@@ -47,8 +47,9 @@ class AsyncReceiver(
     Protocol,
     Generic[ReceiveType],
 ):
-    '''An async receivable duck-type that quacks much like trio's
-    ``trio.abc.ReceieveChannel``.
+    '''
+    An async receivable duck-type that quacks much like trio's
+    ``trio.abc.ReceiveChannel``.
 
     '''
     @abstractmethod
@@ -78,7 +79,8 @@ class AsyncReceiver(
 
 
 class Lagged(trio.TooSlowError):
-    '''Subscribed consumer task was too slow and was overrun
+    '''
+    Subscribed consumer task was too slow and was overrun
     by the fastest consumer-producer pair.
 
     '''
@@ -86,7 +88,8 @@ class Lagged(trio.TooSlowError):
 
 @dataclass
 class BroadcastState:
-    '''Common state to all receivers of a broadcast.
+    '''
+    Common state to all receivers of a broadcast.
 
     '''
     queue: deque
@@ -111,7 +114,8 @@ class BroadcastState:
 
 
 class BroadcastReceiver(ReceiveChannel):
-    '''A memory receive channel broadcaster which is non-lossy for the
+    '''
+    A memory receive channel broadcaster which is non-lossy for the
     fastest consumer.
 
     Additional consumer tasks can receive all produced values by registering


### PR DESCRIPTION
[README blurb](https://github.com/goodboy/tractor/tree/infect_asyncio#infected-asyncio-mode) summarizing this new feature.

What I hope to be a successful attempt at solving #120.

This gets us the following very interesting functionality:
- ability to spawn an actor that has a process entry point of `asyncio.run()`
- the `asyncio` actor embeds `trio` using the [new guest mode](https://github.com/python-trio/trio/blob/master/notes-to-self/aio-guest-test.py) which then enters the `tractor.Actor._async_main()` entry point thus engaging all the std IPC machinery
- the actor is now able to accept requests for async functions which can utilize the new `tractor.to_asyncio.run()` method which allows spawning tasks in the host `asyncio` loop and waiting/streaming the result(s) back into the `trio` task
- results can then be relayed upwards to the parent actor as per normal operation

It ended up being possible to accomplish per task error propagation by simply doing a little state passing inside the callback passed to `asyncio.Task.add_done_callback()` and thus not requiring the use of `anyio`. In fact I'm not even sure it's possible to do this with the task groups offered by `anyio` due to the nature of spawning `asyncio` tasks *from* `trio` tasks and providing an api to acquire the results on demand.

The main idea here is that a new `tractor` actor can be spawned and async functions that will run under `trio` can make calls to spawn `asyncio` tasks using the new `tractor.to_asyncio.run()` routine which acts basically like `tractor.Portal.run()` but without any IPC stuff going on underneath. All IPC is done as normal once results are back in the (embedded) `trio` task.

This basically makes `tractor` integration with `asyncio` frameworks a super cinch now :)

ping @njsmith @oremanj.
If either of you have time to look at this and tell if there's a more *trionic* way it'd be grealy appreciated :smile_cat: 

Further things to be done:
- [x] tests for all of this
- [x] docs & examples
~- [ ] potentially support the existing `trip` backend using the even newer *inside-out-guest-mode* (python-trio/trio#1652) though the plan is to deprecate this anyway (#117)~ trip is being removed in #127.
- ~[ ] using the even newer *inside-out-guest-mode* (python-trio/trio#1652)?~ not yet approved in trio core.

Provisional test list:

- [x] call async func
- ~[ ] call async generator and stream from it~ no longer supported
- [x] error from async func
- [x] error during async streaming
- [x] all the above in remote actors
- ~[ ] `@stream` compatibility?~ unneeded with new api
- ~[ ] `trio_trio` / `from_trio` injection~ don't member why i wrote this
- [x] simple asyncio task error propagation
- [x] trio cancels aio on child side
- [x] cancel via `Portal.cancel_actor()`
- [x] cancel via `trio.move_on_after()` around actor nursery
- [x] asyncio cancels itself and causes a `trio` cancellation
- [x] interloop channel streaming via `to_asyncio.open_channel_from():`
- [x] trio error kills interloop channel in SC style
- [x] trio closes interloop channel early and channel exits
- [x] asyncio error propagates to trio task with interloop channel
- [x] small trio-asyncio echo server