### PR TITLE
First attempt at removing trip & updating hazmat -> lowlevel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,16 @@ matrix:
         - name: "Python 3.7: multiprocessing"
           python: 3.7  # this works for Linux but is ignored on macOS or Windows
           env: SPAWN_BACKEND="mp"
-        - name: "Python 3.7: trio-run-in-process"
+        - name: "Python 3.7: trio"
           python: 3.7  # this works for Linux but is ignored on macOS or Windows
-          env: SPAWN_BACKEND="trio_run_in_process"
+          env: SPAWN_BACKEND="trio"
 
         - name: "Python 3.8: multiprocessing"
           python: 3.8  # this works for Linux but is ignored on macOS or Windows
           env: SPAWN_BACKEND="mp"
-        - name: "Python 3.8: trio-run-in-process"
+        - name: "Python 3.8: trio"
           python: 3.8  # this works for Linux but is ignored on macOS or Windows
-          env: SPAWN_BACKEND="trio_run_in_process"
+          env: SPAWN_BACKEND="trio"
 
 install:
     - cd $TRAVIS_BUILD_DIR

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     install_requires=[
         'msgpack', 'trio>0.8', 'async_generator', 'colorlog', 'wrapt',
-        'trio_typing', 'trio-run-in-process',
+        'trio_typing', 'cloudpickle',
     ],
     tests_require=['pytest'],
     python_requires=">=3.7",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def pytest_addoption(parser):
 
     parser.addoption(
         "--spawn-backend", action="store", dest='spawn_backend',
-        default='trio_run_in_process',
+        default='trio',
         help="Processing spawning backend to use for test run",
     )
 
@@ -34,7 +34,7 @@ def pytest_configure(config):
 
     if backend == 'mp':
         tractor._spawn.try_set_start_method('spawn')
-    elif backend == 'trio_run_in_process':
+    elif backend == 'trio':
         tractor._spawn.try_set_start_method(backend)
 
 
@@ -56,7 +56,7 @@ def pytest_generate_tests(metafunc):
     if not spawn_backend:
         # XXX some weird windows bug with `pytest`?
         spawn_backend = 'mp'
-    assert spawn_backend in ('mp', 'trio_run_in_process')
+    assert spawn_backend in ('mp', 'trio')
 
     if 'start_method' in metafunc.fixturenames:
         if spawn_backend == 'mp':
@@ -67,11 +67,11 @@ def pytest_generate_tests(metafunc):
                 # removing XXX: the fork method is in general
                 # incompatible with trio's global scheduler state
                 methods.remove('fork')
-        elif spawn_backend == 'trio_run_in_process':
+        elif spawn_backend == 'trio':
             if platform.system() == "Windows":
                 pytest.fail(
                     "Only `--spawn-backend=mp` is supported on Windows")
 
-            methods = ['trio_run_in_process']
+            methods = ['trio']
 
         metafunc.parametrize("start_method", methods, scope='module')

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -197,7 +197,7 @@ async def test_cancel_infinite_streamer(start_method):
     ],
 )
 @tractor_test
-async def test_some_cancels_all(num_actors_and_errs, start_method):
+async def test_some_cancels_all(num_actors_and_errs, start_method, loglevel):
     """Verify a subset of failed subactors causes all others in
     the nursery to be cancelled just like the strategy in trio.
 

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -259,7 +259,7 @@ class Actor:
         code (if it exists).
         """
         try:
-            if self._spawn_method == 'trio_run_in_process':
+            if self._spawn_method == 'trio':
                 parent_data = self._parent_main_data
                 if 'init_main_from_name' in parent_data:
                     _mp_fixup_main._fixup_main_from_name(

--- a/tractor/_child.py
+++ b/tractor/_child.py
@@ -1,0 +1,13 @@
+import sys
+import trio
+import cloudpickle
+
+if __name__ == "__main__":
+    job = cloudpickle.load(sys.stdin.detach())
+
+    try:
+        result = trio.run(job)
+        cloudpickle.dump(sys.stdout.detach(), result)
+
+    except BaseException as err:
+        cloudpickle.dump(sys.stdout.detach(), err)

--- a/tractor/_entry.py
+++ b/tractor/_entry.py
@@ -62,7 +62,19 @@ async def _trio_main(
     accept_addr: Tuple[str, int],
     parent_addr: Tuple[str, int] = None
 ) -> None:
+    """Entry point for a `trio_run_in_process` subactor.
+
+    Here we don't need to call `trio.run()` since trip does that as
+    part of its subprocess startup sequence.
+    """
+    if actor.loglevel is not None:
+        log.info(
+            f"Setting loglevel for {actor.uid} to {actor.loglevel}")
+        get_console_log(actor.loglevel)
+
+    log.info(f"Started new trio process for {actor.uid}")
 
     _state._current_actor = actor
 
     await actor._async_main(accept_addr, parent_addr=parent_addr)
+    log.info(f"Actor {actor.uid} terminated")

--- a/tractor/_entry.py
+++ b/tractor/_entry.py
@@ -57,22 +57,12 @@ def _mp_main(
     log.info(f"Actor {actor.uid} terminated")
 
 
-async def _trip_main(
+async def _trio_main(
     actor: 'Actor',
     accept_addr: Tuple[str, int],
     parent_addr: Tuple[str, int] = None
 ) -> None:
-    """Entry point for a `trio_run_in_process` subactor.
 
-    Here we don't need to call `trio.run()` since trip does that as
-    part of its subprocess startup sequence.
-    """
-    if actor.loglevel is not None:
-        log.info(
-            f"Setting loglevel for {actor.uid} to {actor.loglevel}")
-        get_console_log(actor.loglevel)
-
-    log.info(f"Started new TRIP process for {actor.uid}")
     _state._current_actor = actor
+
     await actor._async_main(accept_addr, parent_addr=parent_addr)
-    log.info(f"Actor {actor.uid} terminated")

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -158,13 +158,24 @@ async def cancel_on_completion(
 
 @asynccontextmanager
 async def run_in_process(async_fn, *args, **kwargs):
+    # get arguments that are actors
+    actors_in_args = [
+        arg for arg in args if isinstance(arg, Actor)
+    ]
+    debug_args = []
+    # assume the first is the actor running the function
+    if len(actors_in_args) > 0:
+        subactor = actors_in_args[0]
+        debug_args.append(subactor.uid[0])
+        debug_args.append(subactor.uid[1])
+
     encoded_job = cloudpickle.dumps(partial(async_fn, *args, **kwargs))
     p = await trio.open_process(
         [
             sys.executable,
             "-m",
             _child.__name__
-        ],
+        ] + debug_args,
         stdin=subprocess.PIPE
     )
 

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -168,11 +168,13 @@ async def run_in_process(async_fn, *args, **kwargs):
         stdin=subprocess.PIPE
     )
 
+    # send over func to call
     await p.stdin.send_all(encoded_job)
 
     yield p
 
-    #return cloudpickle.loads(p.stdout)
+    # wait for termination
+    await p.wait()
 
 
 async def new_proc(

--- a/tractor/_state.py
+++ b/tractor/_state.py
@@ -30,7 +30,7 @@ class ActorContextInfo(Mapping):
     def __getitem__(self, key: str):
         try:
             return {
-                'task': trio.hazmat.current_task,
+                'task': trio.lowlevel.current_task,
                 'actor': current_actor
             }[key]().name
         except RuntimeError:

--- a/tractor/testing/_tractor_test.py
+++ b/tractor/testing/_tractor_test.py
@@ -47,7 +47,7 @@ def tractor_test(fn):
             if platform.system() == "Windows":
                 start_method = 'spawn'
             else:
-                start_method = 'trio_run_in_process'
+                start_method = 'trio'
 
         if 'start_method' in inspect.signature(fn).parameters:
             # set of subprocess spawning backends


### PR DESCRIPTION
This branch started as an attempt to remove all `RuntimeWarnings` about `trio.hazmat` deprecation but also turned into dropping [ethereum/trio-run-in-process](https://github.com/ethereum/trio-run-in-process).

- Removed "trio-run-in-process" as a posible backend and added "trio".
- Added `tractor._child` which is the file that gets executed as a module when `run_in_process` is called.
- Based pickle logic on @njsmith comment in: https://github.com/python-trio/trio/issues/5#issuecomment-529272338

I'm getting a bunch of fails on tests and hang, I'm pretty sure it has to do with the tractor machinery not being setup right in the newly spawned processes.