### PR TITLE
Drop cloudpickle dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     install_requires=[
         'msgpack', 'trio>0.8', 'async_generator', 'colorlog', 'wrapt',
-        'trio_typing', 'cloudpickle',
+        'trio_typing',
     ],
     tests_require=['pytest'],
     python_requires=">=3.7",

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -202,7 +202,11 @@ async def cancel_after(wait):
 
 
 @pytest.fixture(scope='module')
-def time_quad_ex(arb_addr):
+def time_quad_ex(arb_addr, travis, spawn_backend):
+    if travis and spawn_backend == 'mp' and (platform.system() != 'Windows'):
+        # no idea, but the travis, mp, linux runs are flaking out here often
+        pytest.skip("Test is too flaky on mp in CI")
+
     timeout = 7 if platform.system() == 'Windows' else 4
     start = time.time()
     results = tractor.run(cancel_after, timeout, arbiter_addr=arb_addr)
@@ -213,9 +217,6 @@ def time_quad_ex(arb_addr):
 
 def test_a_quadruple_example(time_quad_ex, travis, spawn_backend):
     """This also serves as a kind of "we'd like to be this fast test"."""
-    if travis and spawn_backend == 'mp' and (platform.system() != 'Windows'):
-        # no idea, but the travis, mp, linux runs are flaking out here often
-        pytest.skip("Test is too flaky on mp in CI")
 
     results, diff = time_quad_ex
     assert results
@@ -233,10 +234,6 @@ def test_not_fast_enough_quad(
     """Verify we can cancel midway through the quad example and all actors
     cancel gracefully.
     """
-    if travis and spawn_backend == 'mp' and (platform.system() != 'Windows'):
-        # no idea, but the travis, mp, linux runs are flaking out here often
-        pytest.skip("Test is too flaky on mp in CI")
-
     results, diff = time_quad_ex
     delay = max(diff - cancel_delay, 0)
     results = tractor.run(cancel_after, delay, arbiter_addr=arb_addr)

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -576,9 +576,11 @@ class Actor:
                         # initial handshake, report who we are, who they are
                         await self._do_handshake(chan)
 
-                        self._parent_main_data = await chan.recv()
-                        self.rpc_module_paths = await chan.recv()
-                        self.statespace = await chan.recv()
+                        if self._spawn_method == "trio":
+                            # recieve additional init params
+                            self._parent_main_data = await chan.recv()
+                            self.rpc_module_paths = await chan.recv()
+                            self.statespace = await chan.recv()
 
                     except OSError:  # failed to connect
                         log.warning(

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -575,6 +575,11 @@ class Actor:
                         await chan.connect()
                         # initial handshake, report who we are, who they are
                         await self._do_handshake(chan)
+
+                        self._parent_main_data = await chan.recv()
+                        self.rpc_module_paths = await chan.recv()
+                        self.statespace = await chan.recv()
+
                     except OSError:  # failed to connect
                         log.warning(
                             f"Failed to connect to parent @ {parent_addr},"

--- a/tractor/_child.py
+++ b/tractor/_child.py
@@ -1,3 +1,5 @@
+"""This is the "bootloader" for actors started using the native trio backend.
+"""
 import sys
 import trio
 import argparse
@@ -7,9 +9,6 @@ from ast import literal_eval
 from ._actor import Actor
 from ._entry import _trio_main
 
-
-"""This is the "bootloader" for actors started using the native trio backend.
-"""
 
 def parse_uid(arg):
     name, uuid = literal_eval(arg)  # ensure 2 elements
@@ -23,11 +22,9 @@ def parse_ipaddr(arg):
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-
     parser.add_argument("--uid", type=parse_uid)
     parser.add_argument("--loglevel", type=str)
     parser.add_argument("--parent_addr", type=parse_ipaddr)
-
     args = parser.parse_args()
 
     subactor = Actor(

--- a/tractor/_child.py
+++ b/tractor/_child.py
@@ -12,18 +12,12 @@ from ._entry import _trio_main
 """
 
 def parse_uid(arg):
-	uid = literal_eval(arg)
-	assert len(uid) == 2
-	assert isinstance(uid[0], str)
-	assert isinstance(uid[1], str)
-	return uid
+    name, uuid = literal_eval(arg)  # ensure 2 elements
+    return str(name), str(uuid)  # ensures str encoding
 
 def parse_ipaddr(arg):
-	addr = literal_eval(arg)
-	assert len(addr) == 2
-	assert isinstance(addr[0], str)
-	assert isinstance(addr[1], int)
-	return addr
+    host, port = literal_eval(arg)
+    return (str(host), int(port))
 
 
 if __name__ == "__main__":
@@ -40,11 +34,10 @@ if __name__ == "__main__":
         args.uid[0],
         uid=args.uid[1],
         loglevel=args.loglevel,
-	    spawn_method="trio"
-	)
+        spawn_method="trio"
+    )
 
     _trio_main(
         subactor,
-        ("127.0.0.1", 0),
         parent_addr=args.parent_addr
     )

--- a/tractor/_child.py
+++ b/tractor/_child.py
@@ -1,6 +1,53 @@
 import sys
 import trio
-import cloudpickle
+import argparse
+
+from ._actor import Actor
+from ._entry import _trio_main
+
+
+"""This is the "bootloader" for actors started using the native trio backend
+added in #128
+"""
+
 
 if __name__ == "__main__":
-    trio.run(cloudpickle.load(sys.stdin.buffer))
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("name")
+    parser.add_argument("uid")
+    parser.add_argument("loglevel")
+    parser.add_argument("bind_addr")
+    parser.add_argument("parent_addr")
+    parser.add_argument("arbiter_addr")
+
+    args = parser.parse_args()
+
+    bind_addr = args.bind_addr.split(":")
+    bind_addr = (bind_addr[0], int(bind_addr[1]))
+    
+    parent_addr = args.parent_addr.split(":")
+    parent_addr = (parent_addr[0], int(parent_addr[1]))
+
+    arbiter_addr = args.arbiter_addr.split(":")
+    arbiter_addr = (arbiter_addr[0], int(arbiter_addr[1]))
+
+    if args.loglevel == "None":
+        loglevel = None
+    else:
+        loglevel = args.loglevel
+
+    subactor = Actor(
+        args.name,
+        uid=args.uid,
+        loglevel=loglevel,
+        arbiter_addr=arbiter_addr
+    )
+    subactor._spawn_method = "trio"
+
+    _trio_main(
+        subactor,
+        bind_addr,
+        parent_addr=parent_addr
+    )

--- a/tractor/_child.py
+++ b/tractor/_child.py
@@ -2,52 +2,49 @@ import sys
 import trio
 import argparse
 
+from ast import literal_eval
+
 from ._actor import Actor
 from ._entry import _trio_main
 
 
-"""This is the "bootloader" for actors started using the native trio backend
-added in #128
+"""This is the "bootloader" for actors started using the native trio backend.
 """
+
+def parse_uid(arg):
+	uid = literal_eval(arg)
+	assert len(uid) == 2
+	assert isinstance(uid[0], str)
+	assert isinstance(uid[1], str)
+	return uid
+
+def parse_ipaddr(arg):
+	addr = literal_eval(arg)
+	assert len(addr) == 2
+	assert isinstance(addr[0], str)
+	assert isinstance(addr[1], int)
+	return addr
 
 
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("name")
-    parser.add_argument("uid")
-    parser.add_argument("loglevel")
-    parser.add_argument("bind_addr")
-    parser.add_argument("parent_addr")
-    parser.add_argument("arbiter_addr")
+    parser.add_argument("--uid", type=parse_uid)
+    parser.add_argument("--loglevel", type=str)
+    parser.add_argument("--parent_addr", type=parse_ipaddr)
 
     args = parser.parse_args()
 
-    bind_addr = args.bind_addr.split(":")
-    bind_addr = (bind_addr[0], int(bind_addr[1]))
-    
-    parent_addr = args.parent_addr.split(":")
-    parent_addr = (parent_addr[0], int(parent_addr[1]))
-
-    arbiter_addr = args.arbiter_addr.split(":")
-    arbiter_addr = (arbiter_addr[0], int(arbiter_addr[1]))
-
-    if args.loglevel == "None":
-        loglevel = None
-    else:
-        loglevel = args.loglevel
-
     subactor = Actor(
-        args.name,
-        uid=args.uid,
-        loglevel=loglevel,
-        arbiter_addr=arbiter_addr
-    )
-    subactor._spawn_method = "trio"
+        args.uid[0],
+        uid=args.uid[1],
+        loglevel=args.loglevel,
+	    spawn_method="trio"
+	)
 
     _trio_main(
         subactor,
-        bind_addr,
-        parent_addr=parent_addr
+        ("127.0.0.1", 0),
+        parent_addr=args.parent_addr
     )

--- a/tractor/_entry.py
+++ b/tractor/_entry.py
@@ -51,24 +51,31 @@ def _mp_main(
     log.info(f"Actor {actor.uid} terminated")
 
 
-async def _trio_main(
+def _trio_main(
     actor: 'Actor',
     accept_addr: Tuple[str, int],
     parent_addr: Tuple[str, int] = None
 ) -> None:
     """Entry point for a `trio_run_in_process` subactor.
-
-    Here we don't need to call `trio.run()` since trip does that as
-    part of its subprocess startup sequence.
     """
     if actor.loglevel is not None:
         log.info(
             f"Setting loglevel for {actor.uid} to {actor.loglevel}")
         get_console_log(actor.loglevel)
 
-    log.info(f"Started new trio process for {actor.uid}")
+    log.info(
+        f"Started {actor.uid}")
 
     _state._current_actor = actor
 
-    await actor._async_main(accept_addr, parent_addr=parent_addr)
+    log.debug(f"parent_addr is {parent_addr}")
+    trio_main = partial(
+        actor._async_main,
+        accept_addr,
+        parent_addr=parent_addr
+    )
+    try:
+        trio.run(trio_main)
+    except KeyboardInterrupt:
+        pass  # handle it the same way trio does?
     log.info(f"Actor {actor.uid} terminated")

--- a/tractor/_entry.py
+++ b/tractor/_entry.py
@@ -53,7 +53,6 @@ def _mp_main(
 
 def _trio_main(
     actor: 'Actor',
-    accept_addr: Tuple[str, int],
     parent_addr: Tuple[str, int] = None
 ) -> None:
     """Entry point for a `trio_run_in_process` subactor.
@@ -71,7 +70,6 @@ def _trio_main(
     log.debug(f"parent_addr is {parent_addr}")
     trio_main = partial(
         actor._async_main,
-        accept_addr,
         parent_addr=parent_addr
     )
     try:

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -3,11 +3,9 @@ Machinery for actor process spawning using multiple backends.
 """
 import sys
 import inspect
-import subprocess
 import multiprocessing as mp
 import platform
 from typing import Any, Dict, Optional
-from functools import partial
 
 import trio
 from trio_typing import TaskStatus
@@ -29,7 +27,7 @@ from ._state import current_actor
 from .log import get_logger
 from ._portal import Portal
 from ._actor import Actor, ActorFailure
-from ._entry import _mp_main, _trio_main
+from ._entry import _mp_main
 
 
 log = get_logger('tractor')
@@ -160,7 +158,7 @@ async def cancel_on_completion(
 async def spawn_subactor(
     subactor: 'Actor',
     accept_addr: Tuple[str, int],
-    parent_addr: Optional[Tuple[str, int]] = None
+    parent_addr: Tuple[str, int],
 ):
 
     spawn_cmd = [
@@ -232,6 +230,7 @@ async def new_proc(
                     "bind_port": bind_addr[1]
                 })
 
+                # resume caller at next checkpoint now that child is up
                 task_status.started(portal)
 
                 # wait for ActorNursery.wait() to be called

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -227,7 +227,9 @@ async def new_proc(
                     "_parent_main_data": subactor._parent_main_data,
                     "rpc_module_paths": subactor.rpc_module_paths,
                     "statespace": subactor.statespace,
-                    "_arb_addr": subactor._arb_addr
+                    "_arb_addr": subactor._arb_addr,
+                    "bind_host": bind_addr[0],
+                    "bind_port": bind_addr[1]
                 })
 
                 task_status.started(portal)


### PR DESCRIPTION
In the new trio backend, we were using cloudpickle to serialize the async function the child will have to pass to trio to run, but this function never changed, it was `Actor._async_main`, this function handles the connection and handshake with the parent actor.

The real problem was passing the subactor object instance to the newly spawned child.

`tractor._actor.Actor` init function params:
- name: `str`,
- rpc_module_paths: `List[str]`,
- uid: `str`,
- loglevel: `str`,
- arbiter_addr: `Tuple[str, int]`

This parameters are passed through the child shell arguments and parsed using `argparse`.

The problem is the following, when running `tests/_test.py` from the shell this is the output:

```
[guille@hardPC tractor]$ python tests/_test.py 
Jul 25 16:42:27 (no actor context, 161699, tractor._main)) [WARNING] tractor __init__.py:70 No actor could be found @ 127.0.0.1:1616
Jul 25 16:42:27 (no actor context, 161699, tractor._main)) [DEBUG] tractor _actor.py:209 arbiter Loaded RPC modules: {}
Jul 25 16:42:27 (arbiter, 161699, tractor._main)) [INFO] tractor _actor.py:897 Starting local <tractor._actor.Arbiter object at 0x7ff5b0c9ca90> @ 127.0.0.1:1616
Jul 25 16:42:27 (arbiter, 161699, tractor._actor.Actor._serve_forever)) [DEBUG] tractor _actor.py:695 Started tcp server(s) on [<trio.socket.socket fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616)>]
Jul 25 16:42:27 (arbiter, 161699, tractor._actor.Actor._async_main)) [DEBUG] tractor _actor.py:602 Registering <tractor._actor.Arbiter object at 0x7ff5b0c9ca90> for role `arbiter` @ ('127.0.0.1', 1616)
Jul 25 16:42:27 (arbiter, 161699, tractor._actor.Actor._async_main)) [DEBUG] tractor _actor.py:611 Waiting on root nursery to complete
Jul 25 16:42:27 (arbiter, 161699, tractor._main)) [DEBUG] tractor _actor.py:209 __main__ Loaded RPC modules: {'__main__': '/home/guille/Documents/tractor/tests/_test.py'}
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.new_proc)) [INFO] tractor _spawn.py:180 Spawn actor with cmd: ['/home/guille/.pyenv/versions/3.8.4/bin/python', '-m', 'tractor._child', 'some_linguist', '__main__', '6d548b98-2c48-46f3-b069-5940a7383159', 'None', '127.0.0.1:0', '127.0.0.1:1616', '127.0.0.1:1616']
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.new_proc)) [INFO] tractor _spawn.py:214 Started <trio.Process ['/home/guille/.pyenv/versions/3.8.4/bin/python', '-m', 'tractor._child', 'some_linguist', '__main__', '6d548b98-2c48-46f3-b069-5940a7383159', 'None', '127.0.0.1:0', '127.0.0.1:1616', '127.0.0.1:1616']: running with PID 161746>
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.new_proc)) [DEBUG] tractor _actor.py:250 Waiting for peer ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') to connect
/home/guille/.pyenv/versions/3.8.4/lib/python3.8/runpy.py:127: RuntimeWarning: 'tractor._child' found in sys.modules after import of package 'tractor', but prior to execution of 'tractor._child'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [INFO] tractor _actor.py:302 New connection to us <Channel fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43966)>
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor.ipc _ipc.py:131 send `('arbiter', '9ab46a83-9c58-43b2-b5fb-489e2397ae4c')`
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor.ipc _ipc.py:39 received b'\x92\xadsome_linguist\xd9$6d548b98-2c48-46f3-b069-5940a7383159'
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [INFO] tractor _actor.py:809 Handshake with actor ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')@('127.0.0.1', 43966) complete
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:317 Waking channel waiters _ParkingLotStatistics(tasks_waiting=1)
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor _actor.py:326 Registered <Channel fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43966)> for ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:432 Entering msg loop for <Channel fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43966)> from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.new_proc)) [DEBUG] tractor _actor.py:253 ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') successfully connected back to us
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [INFO] tractor _actor.py:302 New connection to us <Channel fd=11, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43968)>
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor.ipc _ipc.py:131 send `('arbiter', '9ab46a83-9c58-43b2-b5fb-489e2397ae4c')`
Jul 25 16:42:27 (arbiter, 161699, tractor._main)) [DEBUG] tractor _actor.py:389 Getting result queue for ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') cid 097c0d6a-6ab3-40ca-b701-10a681cb57d5
Jul 25 16:42:27 (arbiter, 161699, tractor._main)) [DEBUG] tractor _actor.py:414 Sending cmd to ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159'): __main__.cellar_door({})
Jul 25 16:42:27 (arbiter, 161699, tractor._main)) [TRACE] tractor.ipc _ipc.py:131 send `{'cmd': ('__main__', 'cellar_door', {}, ('arbiter', '9ab46a83-9c58-43b2-b5fb-489e2397ae4c'), '097c0d6a-6ab3-40ca-b701-10a681cb57d5')}`
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor.ipc _ipc.py:39 received b'\x92\xadsome_linguist\xd9$6d548b98-2c48-46f3-b069-5940a7383159'
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [INFO] tractor _actor.py:809 Handshake with actor ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')@('127.0.0.1', 43968) complete
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [WARNING] tractor _actor.py:323 already have channel(s) for ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159'):[<Channel fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43966)>]?
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor _actor.py:326 Registered <Channel fd=11, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43968)> for ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:432 Entering msg loop for <Channel fd=11, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43968)> from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor.ipc _ipc.py:39 received b'\x81\xa3cmd\x95\xa4self\xaeregister_actor\x82\xa3uid\x92\xadsome_linguist\xd9$6d548b98-2c48-46f3-b069-5940a7383159\xa8sockaddr\x92\xa9127.0.0.1\xcd\x83\x87\x92\xadsome_linguist\xd9$6d548b98-2c48-46f3-b069-5940a7383159\xd9$bf6ce898-74fe-420f-9a88-e244d512c251'
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor _actor.py:453 Received msg {'cmd': ('self', 'register_actor', {'uid': ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159'), 'sockaddr': ('127.0.0.1', 33671)}, ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159'), 'bf6ce898-74fe-420f-9a88-e244d512c251')} from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:476 Processing request from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
self.register_actor({'uid': ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159'), 'sockaddr': ('127.0.0.1', 33671)})
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:502 Spawning task for <bound method Arbiter.register_actor of <tractor._actor.Arbiter object at 0x7ff5b0c9ca90>>
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor.ipc _ipc.py:39 received b'\x82\xa5error\x82\xa6tb_str\xda\x01mTraceback (most recent call last):\n  File "/home/guille/Documents/tractor/tractor/_actor.py", line 494, in _process_messages\n    func = self._get_rpc_func(ns, funcname)\n  File "/home/guille/Documents/tractor/tractor/_actor.py", line 290, in _get_rpc_func\n    return getattr(self._mods[ns], funcname)\nAttributeError: module \'__main__\' has no attribute \'cellar_door\'\n\xa8type_str\xaeAttributeError\xa3cid\xd9$097c0d6a-6ab3-40ca-b701-10a681cb57d5'
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor _actor.py:453 Received msg {'error': {'tb_str': 'Traceback (most recent call last):\n  File "/home/guille/Documents/tractor/tractor/_actor.py", line 494, in _process_messages\n    func = self._get_rpc_func(ns, funcname)\n  File "/home/guille/Documents/tractor/tractor/_actor.py", line 290, in _get_rpc_func\n    return getattr(self._mods[ns], funcname)\nAttributeError: module \'__main__\' has no attribute \'cellar_door\'\n', 'type_str': 'AttributeError'}, 'cid': '097c0d6a-6ab3-40ca-b701-10a681cb57d5'} from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:376 Delivering {'error': {'tb_str': 'Traceback (most recent call last):\n  File "/home/guille/Documents/tractor/tractor/_actor.py", line 494, in _process_messages\n    func = self._get_rpc_func(ns, funcname)\n  File "/home/guille/Documents/tractor/tractor/_actor.py", line 290, in _get_rpc_func\n    return getattr(self._mods[ns], funcname)\nAttributeError: module \'__main__\' has no attribute \'cellar_door\'\n', 'type_str': 'AttributeError'}, 'cid': '097c0d6a-6ab3-40ca-b701-10a681cb57d5'} from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') to caller 097c0d6a-6ab3-40ca-b701-10a681cb57d5
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:458 Waiting on next msg for <Channel fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43966)> from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, tractor._main)) [ERROR] tractor _trionics.py:249 Nursery for ('arbiter', '9ab46a83-9c58-43b2-b5fb-489e2397ae4c') errored with ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Traceback (most recent call last):
  File "/home/guille/Documents/tractor/tractor/_actor.py", line 494, in _process_messages
    func = self._get_rpc_func(ns, funcname)
  File "/home/guille/Documents/tractor/tractor/_actor.py", line 290, in _get_rpc_func
    return getattr(self._mods[ns], funcname)
AttributeError: module '__main__' has no attribute 'cellar_door'
, 
Traceback (most recent call last):
  File "/home/guille/.pyenv/versions/3.8.4/lib/python3.8/site-packages/tractor/_trionics.py", line 228, in open_nursery
    yield anursery
  File "tests/_test.py", line 16, in test_most_beautiful_word
    portal = await n.run_in_actor('some_linguist', cellar_door)
  File "/home/guille/.pyenv/versions/3.8.4/lib/python3.8/site-packages/tractor/_trionics.py", line 118, in run_in_actor
    await portal._submit_for_result(
  File "/home/guille/.pyenv/versions/3.8.4/lib/python3.8/site-packages/tractor/_portal.py", line 176, in _submit_for_result
    self._expect_result = await self._submit(ns, func, kwargs)
  File "/home/guille/.pyenv/versions/3.8.4/lib/python3.8/site-packages/tractor/_portal.py", line 167, in _submit
    raise unpack_error(first_msg, self.channel)
tractor._exceptions.RemoteActorError: ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Traceback (most recent call last):
  File "/home/guille/Documents/tractor/tractor/_actor.py", line 494, in _process_messages
    func = self._get_rpc_func(ns, funcname)
  File "/home/guille/Documents/tractor/tractor/_actor.py", line 290, in _get_rpc_func
    return getattr(self._mods[ns], funcname)
AttributeError: module '__main__' has no attribute 'cellar_door'

Jul 25 16:42:27 (arbiter, 161699, tractor._main)) [DEBUG] tractor _trionics.py:139 Cancelling nursery
Jul 25 16:42:27 (arbiter, 161699, register_actor)) [TRACE] tractor.ipc _ipc.py:131 send `{'functype': 'function', 'cid': 'bf6ce898-74fe-420f-9a88-e244d512c251'}`
Jul 25 16:42:27 (arbiter, 161699, tractor._portal.Portal.cancel_actor)) [WARNING] tractor _portal.py:273 Sending actor cancel request to ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') on <Channel fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43966)>
Jul 25 16:42:27 (arbiter, 161699, tractor._portal.Portal.cancel_actor)) [DEBUG] tractor _actor.py:389 Getting result queue for ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') cid 73579e25-6bcf-46e4-869c-b80add1a22ae
Jul 25 16:42:27 (arbiter, 161699, tractor._portal.Portal.cancel_actor)) [DEBUG] tractor _actor.py:414 Sending cmd to ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159'): self.cancel({})
Jul 25 16:42:27 (arbiter, 161699, tractor._portal.Portal.cancel_actor)) [TRACE] tractor.ipc _ipc.py:131 send `{'cmd': ('self', 'cancel', {}, ('arbiter', '9ab46a83-9c58-43b2-b5fb-489e2397ae4c'), '73579e25-6bcf-46e4-869c-b80add1a22ae')}`
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.cancel_on_completion)) [DEBUG] tractor _spawn.py:107 Waiting on final result from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.cancel_on_completion)) [WARNING] tractor _portal.py:226 Portal for ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') not expecting a final result?
result() should only be called if subactor was spawned with `ActorNursery.run_in_actor()`
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.cancel_on_completion)) [DEBUG] tractor _spawn.py:123 Returning final result: <class 'tractor._exceptions.NoResult'>
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.cancel_on_completion)) [INFO] tractor _spawn.py:150 Cancelling ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') gracefully after result {result}
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.cancel_on_completion)) [WARNING] tractor _portal.py:273 Sending actor cancel request to ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') on <Channel fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43966)>
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.cancel_on_completion)) [DEBUG] tractor _actor.py:389 Getting result queue for ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') cid 632d00fe-e239-49b3-ad59-ede3e04b7d41
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.cancel_on_completion)) [DEBUG] tractor _actor.py:414 Sending cmd to ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159'): self.cancel({})
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.cancel_on_completion)) [TRACE] tractor.ipc _ipc.py:131 send `{'cmd': ('self', 'cancel', {}, ('arbiter', '9ab46a83-9c58-43b2-b5fb-489e2397ae4c'), '632d00fe-e239-49b3-ad59-ede3e04b7d41')}`
Jul 25 16:42:27 (arbiter, 161699, register_actor)) [TRACE] tractor.ipc _ipc.py:131 send `{'return': None, 'cid': 'bf6ce898-74fe-420f-9a88-e244d512c251'}`
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [INFO] tractor _actor.py:516 RPC func is <bound method Arbiter.register_actor of <tractor._actor.Arbiter object at 0x7ff5b0c9ca90>>
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:521 Waiting on next msg for <Channel fd=11, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43968)> from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor.ipc _ipc.py:39 received b'\x82\xa8functype\xadasyncfunction\xa3cid\xd9$73579e25-6bcf-46e4-869c-b80add1a22ae'
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor _actor.py:453 Received msg {'functype': 'asyncfunction', 'cid': '73579e25-6bcf-46e4-869c-b80add1a22ae'} from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:376 Delivering {'functype': 'asyncfunction', 'cid': '73579e25-6bcf-46e4-869c-b80add1a22ae'} from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') to caller 73579e25-6bcf-46e4-869c-b80add1a22ae
Jul 25 16:42:27 (arbiter, 161699, register_actor)) [INFO] tractor _actor.py:152 All RPC tasks have completed
Task <bound method Actor.cancel of <tractor._actor.Actor object at 0x7f3a115f5850>> was likely cancelled before it was started
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:458 Waiting on next msg for <Channel fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43966)> from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [ERROR] tractor.ipc _ipc.py:41 Stream connection ('127.0.0.1', 43966) broke
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor.ipc _ipc.py:145 Closing <Channel fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616)>
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [TRACE] tractor.ipc _ipc.py:39 received b''
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor.ipc _ipc.py:45 Stream connection ('127.0.0.1', 43968) was closed
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor.ipc _ipc.py:145 Closing <Channel fd=11, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 1616), raddr=('127.0.0.1', 43968)>
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:525 <Channel [closed] fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6> from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') disconnected
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:543 Exiting msg loop for <Channel [closed] fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6> from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') with last msg:
{'functype': 'asyncfunction', 'cid': '73579e25-6bcf-46e4-869c-b80add1a22ae'}
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:336 Releasing channel <Channel [closed] fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6> from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:343 Peers is defaultdict(<class 'list'>, {('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159'): [<Channel [closed] fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>]})
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:525 <Channel [closed] fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6> from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') disconnected
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:543 Exiting msg loop for <Channel [closed] fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6> from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159') with last msg:
{'cmd': ('self', 'register_actor', {'uid': ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159'), 'sockaddr': ('127.0.0.1', 33671)}, ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159'), 'bf6ce898-74fe-420f-9a88-e244d512c251')}
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:336 Releasing channel <Channel [closed] fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6> from ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:340 No more channels for ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:343 Peers is defaultdict(<class 'list'>, {})
Jul 25 16:42:27 (arbiter, 161699, trio._highlevel_serve_listeners._run_handler)) [DEBUG] tractor _actor.py:347 Signalling no more peer channels
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.new_proc)) [DEBUG] tractor _spawn.py:328 Joined <trio.Process ['/home/guille/.pyenv/versions/3.8.4/bin/python', '-m', 'tractor._child', 'some_linguist', '__main__', '6d548b98-2c48-46f3-b069-5940a7383159', 'None', '127.0.0.1:0', '127.0.0.1:1616', '127.0.0.1:1616']: exited with status 0>
Jul 25 16:42:27 (arbiter, 161699, tractor._spawn.new_proc)) [WARNING] tractor _spawn.py:334 Cancelling existing result waiter task for ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:28 (arbiter, 161699, tractor._portal.Portal.cancel_actor)) [WARNING] tractor _portal.py:283 May have failed to cancel ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:28 (arbiter, 161699, tractor._spawn.cancel_on_completion)) [WARNING] tractor _portal.py:283 May have failed to cancel ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Jul 25 16:42:28 (arbiter, 161699, tractor._main)) [WARNING] tractor _trionics.py:278 Nursery cancelling due to ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Traceback (most recent call last):
  File "/home/guille/Documents/tractor/tractor/_actor.py", line 494, in _process_messages
    func = self._get_rpc_func(ns, funcname)
  File "/home/guille/Documents/tractor/tractor/_actor.py", line 290, in _get_rpc_func
    return getattr(self._mods[ns], funcname)
AttributeError: module '__main__' has no attribute 'cellar_door'

Jul 25 16:42:28 (arbiter, 161699, tractor._actor.Actor._async_main)) [DEBUG] tractor _actor.py:661 All peer channels are complete
Jul 25 16:42:28 (arbiter, 161699, tractor._actor.Actor._async_main)) [DEBUG] tractor _actor.py:774 Shutting down channel server
Traceback (most recent call last):
  File "tests/_test.py", line 23, in <module>
    tractor.run(test_most_beautiful_word)
  File "/home/guille/.pyenv/versions/3.8.4/lib/python3.8/site-packages/tractor/__init__.py", line 114, in run
    return trio.run(_main, async_fn, args, kwargs, arbiter_addr, name)
  File "/home/guille/.pyenv/versions/3.8.4/lib/python3.8/site-packages/trio/_core/_run.py", line 1896, in run
    raise runner.main_task_outcome.error
  File "/home/guille/.pyenv/versions/3.8.4/lib/python3.8/site-packages/tractor/__init__.py", line 91, in _main
    return await _start_actor(
  File "/home/guille/.pyenv/versions/3.8.4/lib/python3.8/site-packages/tractor/_actor.py", line 908, in _start_actor
    result = await main()
  File "tests/_test.py", line 16, in test_most_beautiful_word
    portal = await n.run_in_actor('some_linguist', cellar_door)
  File "/home/guille/.pyenv/versions/3.8.4/lib/python3.8/site-packages/tractor/_trionics.py", line 118, in run_in_actor
    await portal._submit_for_result(
  File "/home/guille/.pyenv/versions/3.8.4/lib/python3.8/site-packages/tractor/_portal.py", line 176, in _submit_for_result
    self._expect_result = await self._submit(ns, func, kwargs)
  File "/home/guille/.pyenv/versions/3.8.4/lib/python3.8/site-packages/tractor/_portal.py", line 167, in _submit
    raise unpack_error(first_msg, self.channel)
tractor._exceptions.RemoteActorError: ('some_linguist', '6d548b98-2c48-46f3-b069-5940a7383159')
Traceback (most recent call last):
  File "/home/guille/Documents/tractor/tractor/_actor.py", line 494, in _process_messages
    func = self._get_rpc_func(ns, funcname)
  File "/home/guille/Documents/tractor/tractor/_actor.py", line 290, in _get_rpc_func
    return getattr(self._mods[ns], funcname)
AttributeError: module '__main__' has no attribute 'cellar_door'


```

Closes #131 

