### PR TITLE
Testing remote capabilities using virtual networks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,36 @@ jobs:
       - name: Install dependencies
         run: pip install -U . -r requirements-test.txt -r requirements-docs.txt --upgrade-strategy eager
       - name: Run tests
-        run: pytest tests/ --spawn-backend=${{ matrix.spawn_backend }}
+        run: pytest tests/ --spawn-backend=${{ matrix.spawn_backend }} --ignore=tests/multihost
+
+  multihost_testing:
+    name: 'multihost Python ${{ matrix.python }} - ${{ matrix.spawn_backend }}'
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.7', '3.8']
+        spawn_backend: ['trio', 'mp']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout Mininet
+        uses: actions/checkout@v2
+        with:
+          repository: 'mininet/mininet'
+          path: mininet
+      - name: Setup python
+        run: sudo apt-get install python${{ matrix.python }} python3-setuptools
+      - name: Update pip
+        run: sudo python${{ matrix.python }} -m pip install -U pip
+      - name: Install Mininet
+        run: sudo bash $GITHUB_WORKSPACE/mininet/util/install.sh -nfv
+      - name: Install pytest-vnet
+        run: sudo python${{ matrix.python }} -m pip install git+git://github.com/guilledk/pytest-vnet.git
+      - name: Install dependencies
+        run: sudo python${{ matrix.python }} -m pip install -U . -r requirements-test.txt -r requirements-docs.txt --upgrade-strategy eager
+      - name: Start Mininet backend
+        run: sudo service openvswitch-switch start && sudo ovs-vsctl set-manager ptcp:6640
+      - name: Run tests
+        run: sudo python${{ matrix.python }} -m pytest tests/multihost --spawn-backend=${{ matrix.spawn_backend }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,46 +4,6 @@ sudo: required
 
 matrix:
     include:
-        - name: "Windows, Python Latest: multiprocessing"
-          os: windows
-          language: sh
-          python: 3.x  # only works on linux
-          env: SPAWN_BACKEND="mp"
-          before_install:
-              - choco install python3 --params "/InstallDir:C:\\Python"
-              - export PATH="/c/Python:/c/Python/Scripts:$PATH"
-              - python -m pip install --upgrade pip wheel
-
-        - name: "Windows, Python Latest: trio"
-          os: windows
-          language: sh
-          python: 3.x  # only works on linux
-          env: SPAWN_BACKEND="trio"
-          before_install:
-              - choco install python3 --params "/InstallDir:C:\\Python"
-              - export PATH="/c/Python:/c/Python/Scripts:$PATH"
-              - python -m pip install --upgrade pip wheel
-
-        - name: "Windows, Python 3.7: multiprocessing"
-          os: windows
-          python: 3.7  # only works on linux
-          env: SPAWN_BACKEND="mp"
-          language: sh
-          before_install:
-              - choco install python3 --version 3.7.4 --params "/InstallDir:C:\\Python"
-              - export PATH="/c/Python:/c/Python/Scripts:$PATH"
-              - python -m pip install --upgrade pip wheel
-
-        - name: "Windows, Python 3.7: trio"
-          os: windows
-          python: 3.7  # only works on linux
-          env: SPAWN_BACKEND="trio"
-          language: sh
-          before_install:
-              - choco install python3 --version 3.7.4 --params "/InstallDir:C:\\Python"
-              - export PATH="/c/Python:/c/Python/Scripts:$PATH"
-              - python -m pip install --upgrade pip wheel
-
         - name: "Python 3.7: multiprocessing"
           python: 3.7  # this works for Linux but is ignored on macOS or Windows
           env: SPAWN_BACKEND="mp"
@@ -58,13 +18,22 @@ matrix:
           python: 3.8  # this works for Linux but is ignored on macOS or Windows
           env: SPAWN_BACKEND="trio"
 
-        - name: "Multi Host: multiprocessing"
+        - name: "Multi Host Python 3.8: multiprocessing"
           services: docker
           python: 3.8  # this works for Linux but is ignored on macOS or Windows
           script: pytest tests/  --spawn-backend=mp -m run_in_netvm
-        - name: "Multi Host: trio"
+        - name: "Multi Host Python 3.8: trio"
           services: docker
           python: 3.8  # this works for Linux but is ignored on macOS or Windows
+          script: pytest tests/  --spawn-backend=trio -m run_in_netvm
+
+        - name: "Multi Host Python 3.7: multiprocessing"
+          services: docker
+          python: 3.7  # this works for Linux but is ignored on macOS or Windows
+          script: pytest tests/  --spawn-backend=mp -m run_in_netvm
+        - name: "Multi Host Python 3.7: trio"
+          services: docker
+          python: 3.7  # this works for Linux but is ignored on macOS or Windows
           script: pytest tests/  --spawn-backend=trio -m run_in_netvm
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 dist: xenial
 sudo: required
-services:
-    - docker
 
 matrix:
     include:
@@ -60,6 +58,15 @@ matrix:
           python: 3.8  # this works for Linux but is ignored on macOS or Windows
           env: SPAWN_BACKEND="trio"
 
+        - name: "Multi Host: multiprocessing"
+          services: docker
+          python: 3.8  # this works for Linux but is ignored on macOS or Windows
+          script: pytest tests/  --spawn-backend=mp -m run_in_netvm
+        - name: "Multi Host: trio"
+          services: docker
+          python: 3.8  # this works for Linux but is ignored on macOS or Windows
+          script: pytest tests/  --spawn-backend=trio -m run_in_netvm
+
 install:
     - cd $TRAVIS_BUILD_DIR
     - pip install -U pip
@@ -67,4 +74,4 @@ install:
 
 script:
     - mypy tractor/ --ignore-missing-imports
-    - pytest tests/  --spawn-backend=${SPAWN_BACKEND}
+    - pytest tests/  --spawn-backend=${SPAWN_BACKEND} --disable-vnet

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 dist: xenial
 sudo: required
+services:
+    - docker
 
 matrix:
     include:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,4 +3,5 @@ pytest-trio
 pdbpp
 mypy
 trio_typing
+docker
 git+git://github.com/guilledk/pytest-vnet.git

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ pytest-trio
 pdbpp
 mypy
 trio_typing
+git+git://github.com/guilledk/pytest-vnet.git

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,5 +3,3 @@ pytest-trio
 pdbpp
 mypy
 trio_typing
-docker
-git+git://github.com/guilledk/pytest-vnet.git

--- a/tests/multihost/test_simple.py
+++ b/tests/multihost/test_simple.py
@@ -1,6 +1,5 @@
-from pytest_vnet import run_in_netvm
+from pytest_vnet import as_host
 
-@run_in_netvm
 def test_remote_actor_simple():
 
     switch = vnet.addSwitch('s0')
@@ -31,13 +30,17 @@ def test_remote_actor_simple():
                 pass
 
         tractor.run(main)
+        print('done')
 
     vnet.start()
     daemon.start_host()
     client.start_host()
     client.proc.wait(timeout=3)
+    client_out = client.proc.stdout.read().decode('utf-8').rstrip()
+    print(client_out)
+    assert 'done' in client_out
 
-@run_in_netvm
+
 def test_internet_hello():
     """
        'internet'
@@ -105,6 +108,7 @@ def test_internet_hello():
                     assert await portal.get_motd() == "Hello intranet friends!"
 
             tractor.run(main)
+            print('done')
 
         clients.append(motd_client)
 
@@ -114,4 +118,7 @@ def test_internet_hello():
         client.start_host()
 
     for client in clients:
-        client.proc.wait(timeout=5)
+        client.proc.wait(timeout=3)
+        client_out = client.proc.stdout.read().decode('utf-8').rstrip()
+        print(client_out)
+        assert 'done' in client_out

--- a/tests/test_multi_host.py
+++ b/tests/test_multi_host.py
@@ -3,16 +3,16 @@ from pytest_vnet import run_in_netvm
 @run_in_netvm
 def test_remote_actor_simple():
 
-    s3 = vnet.addSwitch('s3')
+    switch = vnet.addSwitch('s0')
 
-    @as_host(vnet, 'h1', '10.0.0.1', s3)
+    @as_host(vnet, 'h1', switch, ip='10.0.0.1')
     def daemon():
         import tractor
         tractor.run_daemon(
             (), arbiter_addr=daemon_addr
         )
 
-    @as_host(vnet, 'h2', '10.0.0.1', s3)
+    @as_host(vnet, 'h2', switch, ip='10.0.0.1')
     def client():
         import time
         import tractor
@@ -36,3 +36,82 @@ def test_remote_actor_simple():
     daemon.start_host()
     client.start_host()
     client.proc.wait(timeout=3)
+
+@run_in_netvm
+def test_internet_hello():
+    """
+       'internet'
+       server (h0)
+           |
+       switch (s0)
+           |
+    ----------------
+    |              |
+   isp 1          isp 2
+   (nat1)         (nat2)
+    |              |
+  switch 1       switch 2
+   (s1)           (s2)
+    |              |
+  client 1       client 2
+   (h1)           (h2)
+
+    """
+
+    switch_inet = vnet.addSwitch('s0')
+   
+    @as_host(vnet, 'h0', switch_inet)
+    def motd_server():
+        import tractor
+
+        async def get_motd():
+            return "Hello intranet friends!"
+
+        tractor.run_daemon(
+            (__file__), arbiter_addr=daemon_addr
+        )
+
+    clients = []
+
+    for i in range(1, 3):
+        inet_iface = f"nat_{i}-eth0"
+        local_iface = f"nat_{i}-eth1"
+        local_addr = f"192.168.{i}.1"
+        local_subnet = f"192.168.{i}.0/24"
+        nat_params = { 'ip' : f"{local_addr}/24" }
+
+        vnet.ipBase = local_subnet
+        # ^ needed to overwrite default subnet passed to addNAT
+        nat = vnet.addNAT(
+            f"nat{i}",
+            inetIntf=inet_iface,
+            localIntf=local_iface
+        )
+
+        switch = vnet.addSwitch(f"s{i}")
+        vnet.addLink(nat, switch_inet, intfName1=inet_iface)
+        vnet.addLink(nat, switch, intfName1=local_iface, params1=nat_params)
+
+        @as_host(
+            vnet, f"h{i}", switch,
+            ip=f"192.168.{i}.100/24",
+            defaultRoute=f"via {local_addr}"
+        )
+        def motd_client():
+            import tractor
+
+            async def main():
+                async with tractor.get_arbiter('10.0.0.1') as portal:
+                    assert await portal.get_motd() == "Hello intranet friends!"
+
+            tractor.run(main)
+
+        clients.append(motd_client)
+
+    vnet.start()
+    motd_server.start_host()
+    for client in clients:
+        client.start_host()
+
+    for client in clients:
+        client.proc.wait(timeout=5)

--- a/tests/test_multi_host.py
+++ b/tests/test_multi_host.py
@@ -1,0 +1,38 @@
+from pytest_vnet import run_in_netvm
+
+@run_in_netvm
+def test_remote_actor_simple():
+
+    s3 = vnet.addSwitch('s3')
+
+    @as_host(vnet, 'h1', '10.0.0.1', s3)
+    def daemon():
+        import tractor
+        tractor.run_daemon(
+            (), arbiter_addr=daemon_addr
+        )
+
+    @as_host(vnet, 'h2', '10.0.0.1', s3)
+    def client():
+        import time
+        import tractor
+
+        async def main():
+            async with tractor.get_arbiter(daemon_addr) as portal:
+                await portal.cancel_actor()
+
+            time.sleep(0.1)
+
+            # no arbiter socket should exist
+            try:
+                async with tractor.get_arbiter(daemon_addr) as portal:
+                    assert False  # this shouldn't run
+            except OSError:
+                pass
+
+        tractor.run(main)
+
+    vnet.start()
+    daemon.start_host()
+    client.start_host()
+    client.proc.wait(timeout=3)


### PR DESCRIPTION
This starts to address #124 

[pytest-vnet](https://github.com/guilledk/pytest-vnet) does most of the heavy work, creates a docker container from this [docker image](https://hub.docker.com/layers/guilledk/pytest-vnet/netvm/images/sha256-bae1b08dccad560b44ff964e50eb53e415f6bb217dcfee1d9f5d2a019a70f5ee?context=explore) based on debian, it installs the latest [mininet](https://github.com/mininet/mininet) release from its github and sets up python build essentials, on the first run it will install python inside the container and save a snapshot for each python version it installs, to avoid repeating the process.

From mininet.org: "Mininet creates a realistic virtual network, running real kernel, switch and application code, on a single machine (VM, cloud or native)"

To use this virutal net, `pytest-vnet` allows us to mark our regular test functions with the decorator `@run_in_netvm`, here is a full example:

```python
@run_in_netvm
def test_vsocket_hello():

    s3 = vnet.addSwitch("s3")

    @as_host(vnet, 'h1', '10.0.0.1', s3)
    def receiver():
        import socket
        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
            s.bind(('', 50007))
            s.listen(1)
            conn, addr = s.accept()
            with conn:
                data = conn.recv(1024)
                assert data == b"Hello world through a virtual socket!"

    @as_host(vnet, 'h2', '10.0.0.2', s3)
    def sender():
        import socket
        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
            s.connect(('10.0.0.1', 50007))
            s.sendall("Hello world through a virtual socket!".encode('utf-8'))

    vnet.start()
    receiver.start_host()
    sender.start_host()
    receiver.proc.wait(timeout=3)
```

Test functions marked with `@run_in_netvm` will be loaded as a script inside the running docker container, and the following code will be injected on them:

```python
import sys
import logging
import traceback
"""
a bunch of sys.path.appends to hook the vms python env to the host
"""
from mininet.net import Mininet
from mininet.node import Controller
# To disable resource limit error message in mininet
from mininet.log import setLogLevel
setLogLevel("critical")
# Additional tools inside vm scripts
from pytest_vnet import as_script, as_host
vnet = Mininet(controller=Controller)
try:
    vnet.addController('c0')
    """
    actuall func code
    """
except Exception as e:
    sys.stderr.write(traceback.format_exc())

vnet.stop()
```

As you can see by default a bunch of packages are imported and an empty virtual net is created: `vnet`, this network gets automatically stopped at the end of the script. That try catch is to properly relay exceptions to pytest in the future, for now, the traceback format exec gets thrown into `stderr`

 Then each function marked with `@as_host` gets loaded to the netvm as a separate script but also it will create a new `mininet` host and link to the network, here is the decorator code:
```python
def as_host(vnet, hostname, addr, link):

    def wrapper(func):
        func = as_script(func)  # only inject sys path appends and nothing else
        func.host = vnet.addHost(hostname, ip=addr)
        vnet.addLink(func.host, link)
        def _start_proc():
            func.proc = func.host.popen(["python3", func.path])
        func.start_host = _start_proc
        return func

    return wrapper
```
To actually start the process one must call `as_host_wrapped_func.start_host()`.

*disclaimer: `pytest-vnet` is in very early development*