### PR TITLE
Install docs requirements in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
 install:
     - cd $TRAVIS_BUILD_DIR
     - pip install -U pip
-    - pip install -U . -r requirements-test.txt --upgrade-strategy eager
+    - pip install -U . -r requirements-test.txt -r requirements-docs.txt --upgrade-strategy eager
 
 script:
     - mypy tractor/ --ignore-missing-imports


### PR DESCRIPTION
Small gaf on my part, in #137 I put the docs requirements in a separate file and forgot to update the `.travis.yml` file to also install that file when running tests.