### PR TITLE
Typelog sphinx theme wrong name on requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
 install:
     - cd $TRAVIS_BUILD_DIR
     - pip install -U pip
-    - pip install -U . -r requirements-test.txt --upgrade-strategy eager
+    - pip install -U . -r requirements-test.txt -r requirements-docs.txt --upgrade-strategy eager
 
 script:
     - mypy tractor/ --ignore-missing-imports

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,2 @@
 sphinx
-sphinx_typlog_theme
+sphinx-typlog-theme


### PR DESCRIPTION
Fixes bug introduced in #150.
Double gaf, wrong name on the `requirements-docs.txt` for the typelog sphinx theme.
