### PR TITLE
Drop warn

### DIFF
--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -426,7 +426,7 @@ async def spawn():
         portal = await tn.run_in_actor('sleeper', spin_for)
 
 
-# @no_windows
+@no_windows
 def test_cancel_while_childs_child_in_sync_sleep(
     loglevel,
     start_method,

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -426,7 +426,7 @@ async def spawn():
         portal = await tn.run_in_actor('sleeper', spin_for)
 
 
-@no_windows
+# @no_windows
 def test_cancel_while_childs_child_in_sync_sleep(
     loglevel,
     start_method,

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -1083,19 +1083,12 @@ async def _start_actor(
         try:
             result = await main()
         except (Exception, trio.MultiError) as err:
-            try:
-                log.exception("Actor crashed:")
-                await _debug._maybe_enter_pm(err)
+            log.exception("Actor crashed:")
+            await _debug._maybe_enter_pm(err)
 
-                raise
-
-            finally:
-                await actor.cancel()
-
-        # XXX: the actor is cancelled when this context is complete
-        # given that there are no more active peer channels connected
-        actor.cancel_server()
-        actor._service_n.cancel_scope.cancel()
+            raise
+        finally:
+            await actor.cancel()
 
     # unset module state
     _state._current_actor = None

--- a/tractor/_forkserver_override.py
+++ b/tractor/_forkserver_override.py
@@ -234,8 +234,8 @@ def main(listener_fd, alive_r, preload, main_path=None, sys_path=None):
                             os.close(child_w)
                         else:
                             # This shouldn't happen really
-                            warnings.warn('forkserver: waitpid returned '
-                                          'unexpected pid %d' % pid)
+                            warnings.warning('forkserver: waitpid returned '
+                                             'unexpected pid %d' % pid)
 
                 if listener in rfds:
                     # Incoming fork request

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -275,7 +275,7 @@ async def open_nursery() -> typing.AsyncGenerator[ActorNursery, None]:
                 # ria_nursery scope end
 
         # XXX: do we need a `trio.Cancelled` catch here as well?
-        except (Exception, trio.MultiError) as err:
+        except (Exception, trio.MultiError, trio.Cancelled) as err:
             # If actor-local error was raised while waiting on
             # ".run_in_actor()" actors then we also want to cancel all
             # remaining sub-actors (due to our lone strategy:


### PR DESCRIPTION
`warnings.warn()` is deprecated, yes I know.

Also plops in `Actor.cancel()` at the end of the root actor's main task for consistency (not sure why we weren't doing this before).