### PR TITLE
Debug refine

### DIFF
--- a/examples/debugging/multi_daemon_subactors.py
+++ b/examples/debugging/multi_daemon_subactors.py
@@ -1,0 +1,31 @@
+import tractor
+import trio
+
+
+async def breakpoint_forever():
+    "Indefinitely re-enter debugger in child actor."
+    while True:
+        yield 'yo'
+        await tractor.breakpoint()
+
+
+async def name_error():
+    "Raise a ``NameError``"
+    getattr(doggypants)
+
+
+async def main():
+    """Test breakpoint in a streaming actor.
+    """
+    async with tractor.open_nursery() as n:
+
+        p0 = await n.start_actor('bp_forever', rpc_module_paths=[__name__])
+        p1 = await n.start_actor('name_error', rpc_module_paths=[__name__])
+
+        # retreive results
+        stream = await p0.run(__name__, 'breakpoint_forever')
+        await p1.run(__name__, 'name_error')
+
+
+if __name__ == '__main__':
+    tractor.run(main, debug_mode=True, loglevel='error')

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -282,6 +282,34 @@ def test_multi_subactors(spawn):
     assert 'bdb.BdbQuit' in before
 
 
+def test_multi_daemon_subactors(spawn):
+    """Multiple daemon subactors, both erroring and breakpointing within a
+    stream.
+    """
+    child = spawn('multi_daemon_subactors')
+
+    child.expect(r"\(Pdb\+\+\)")
+
+    before = str(child.before.decode())
+    assert "Attaching pdb to actor: ('bp_forever'" in before
+
+    child.sendline('c')
+
+    # first name_error failure
+    child.expect(r"\(Pdb\+\+\)")
+    before = str(child.before.decode())
+    assert "NameError" in before
+
+    child.sendline('c')
+
+    child.expect(r"\(Pdb\+\+\)")
+    before = str(child.before.decode())
+    assert "tractor._exceptions.RemoteActorError: ('name_error'" in before
+
+    child.sendline('c')
+    child.expect(pexpect.EOF)
+
+
 def test_multi_subactors_root_errors(spawn):
     """Multiple subactors, both erroring and breakpointing as well as
     a nested subactor erroring.

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -301,7 +301,18 @@ class Actor:
         try:
             return getattr(self._mods[ns], funcname)
         except KeyError as err:
-            raise ModuleNotExposed(*err.args)
+            mne = ModuleNotExposed(*err.args)
+
+            if ns == '__main__':
+                msg = (
+                    "\n\nMake sure you exposed the current module using:\n\n"
+                    "ActorNursery.start_actor(<name>, rpc_module_paths="
+                    "[__name__])"
+                )
+
+                mne.msg += msg
+
+            raise mne
 
     async def _stream_handler(
         self,
@@ -591,7 +602,7 @@ class Actor:
                 # Receive runtime state from our parent
                 parent_data = await chan.recv()
                 log.debug(
-                    "Recieved state from parent:\n"
+                    "Received state from parent:\n"
                     f"{parent_data}"
                 )
                 accept_addr = (
@@ -599,6 +610,7 @@ class Actor:
                     parent_data.pop('bind_port'),
                 )
                 rvs = parent_data.pop('_runtime_vars')
+                log.debug(f"Runtime vars are: {rvs}")
                 rvs['_is_root'] = False
                 _state._runtime_vars.update(rvs)
 

--- a/tractor/_discovery.py
+++ b/tractor/_discovery.py
@@ -42,6 +42,7 @@ async def get_root(
 **kwargs,
 ) -> typing.AsyncGenerator[Union[Portal, LocalPortal], None]:
     host, port = _runtime_vars['_root_mailbox']
+    assert host is not None
     async with _connect_chan(host, port) as chan:
         async with open_portal(chan, **kwargs) as portal:
             yield portal


### PR DESCRIPTION
In piker we rely on hooking into `tractor._main()` so set the `_is_root` runtime var in there instead.

Toss in another debugger test for good measure :surfer: 