### PR TITLE
Drop duplicate project-package name in msg header

### DIFF
--- a/tractor/log.py
+++ b/tractor/log.py
@@ -55,7 +55,15 @@ def get_logger(
     '''Return the package log or a sub-log for `name` if provided.
     '''
     log = rlog = logging.getLogger(_root_name)
+
     if name and name != _proj_name:
+
+        # handling for modules that use ``get_logger(__name__)`` to
+        # avoid duplicate project-package token in msg output
+        rname, _, tail = name.partition('.')
+        if rname == _root_name:
+            name = tail
+
         log = rlog.getChild(name)
         log.level = rlog.level
 


### PR DESCRIPTION
For projects that use the internal pretty logging system (such as `piker`) it's annoying to see the project-package name duplicated in log msg headers when using `tractor.log.get_logger(__name__)` from inside the client module:

prefer `piker.mod.submod submod.py:439` vs `piker.piker.mod.submod submod.py:439`

This just strips that duplicate token if detected while still keep the child logging hierarchy in tact. 