### PR TITLE
Flip to using the `trio` spawner on windows

### DIFF
--- a/newsfragments/166.feature.rst
+++ b/newsfragments/166.feature.rst
@@ -1,0 +1,4 @@
+Switch to using the ``trio`` process spawner by default on windows.
+
+This gets windows users debugger support (manually tested) and in
+general a more resilient (nested) actor tree implementation.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('docs/README.rst', encoding='utf-8') as f:
 
 setup(
     name="tractor",
-    version='0.1.0a2',  # alpha zone
+    version='0.1.0a3.dev0',  # alpha zone
     description='structured concurrrent "actors"',
     long_description=readme,
     license='GPLv3',

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -38,18 +38,17 @@ log = get_logger('tractor')
 
 # placeholder for an mp start context if so using that backend
 _ctx: Optional[mp.context.BaseContext] = None
-_spawn_method: str = "spawn"
+_spawn_method: str = "trio"
 
 
 if platform.system() == 'Windows':
-    _spawn_method = "spawn"
+
     _ctx = mp.get_context("spawn")
 
     async def proc_waiter(proc: mp.Process) -> None:
         await trio.lowlevel.WaitForSingleObject(proc.sentinel)
 else:
-    # *NIX systems use ``trio`` primitives as our default
-    _spawn_method = "trio"
+    # *NIX systems use ``trio`` primitives as our default as well
 
     async def proc_waiter(proc: mp.Process) -> None:
         await trio.lowlevel.wait_readable(proc.sentinel)


### PR DESCRIPTION
Was able to try it manually on a windows 10 system and the debugger
works great!