### PR TITLE
End the `pdb` SIGINT handling madness

### DIFF
--- a/examples/debugging/root_cancelled_but_child_is_in_tty_lock.py
+++ b/examples/debugging/root_cancelled_but_child_is_in_tty_lock.py
@@ -39,7 +39,8 @@ async def main():
         portal = await n.run_in_actor('spawner0', spawn_until, depth=0)
         portal1 = await n.run_in_actor('spawner1', spawn_until, depth=1)
 
-        # nursery cancellation should be triggered due to propagated error
+        # nursery cancellation should be triggered due to propagated
+        # error from child.
         await portal.result()
         await portal1.result()
 

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -117,9 +117,13 @@ async def _main(
     # Note that if the current actor is the arbiter it is desirable
     # for it to stay up indefinitely until a re-election process has
     # taken place - which is not implemented yet FYI).
-    return await _start_actor(
-        actor, main, host, port, arbiter_addr=arbiter_addr
-    )
+
+    try:
+        return await _start_actor(
+            actor, main, host, port, arbiter_addr=arbiter_addr
+        )
+    finally:
+        logger.info("Root actor terminated")
 
 
 def run(

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -821,7 +821,7 @@ class Actor:
         self._server_down = trio.Event()
         try:
             async with trio.open_nursery() as server_n:
-                listeners: List[trio.abc.Listener] = await server_n.start(
+                l: List[trio.abc.Listener] = await server_n.start(
                     partial(
                         trio.serve_tcp,
                         self._stream_handler,
@@ -832,9 +832,10 @@ class Actor:
                         host=accept_host,
                     )
                 )
-                log.debug("Started tcp server(s) on"  # type: ignore
-                          f" {[l.socket for l in listeners]}")
-                self._listeners.extend(listeners)
+                log.debug(
+                    "Started tcp server(s) on"
+                    f" {[getattr(l, 'socket', 'unknown socket') for l in l]}")
+                self._listeners.extend(l)
                 task_status.started(server_n)
         finally:
             # signal the server is down since nursery above terminated

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -767,8 +767,8 @@ class Actor:
         finally:
             log.info("Root nursery complete")
 
-            # tear down all lifetime contexts
-            # api idea: ``tractor.open_context()``
+            # tear down all lifetime contexts if not in guest mode
+            # XXX: should this just be in the entrypoint?
             log.warning("Closing all actor lifetime contexts")
             self._lifetime_stack.close()
 

--- a/tractor/_entry.py
+++ b/tractor/_entry.py
@@ -15,7 +15,7 @@ log = get_logger(__name__)
 
 
 def _mp_main(
-    actor: 'Actor',  # noqa
+    actor: 'Actor',  # type: ignore
     accept_addr: Tuple[str, int],
     forkserver_info: Tuple[Any, Any, Any, Any, Any],
     start_method: str,
@@ -54,8 +54,9 @@ def _mp_main(
 
 
 def _trio_main(
-    actor: 'Actor',  # noqa
-    parent_addr: Tuple[str, int] = None
+    actor: 'Actor',  # type: ignore
+    *,
+    parent_addr: Tuple[str, int] = None,
 ) -> None:
     """Entry point for a `trio_run_in_process` subactor.
     """

--- a/tractor/_entry.py
+++ b/tractor/_entry.py
@@ -7,7 +7,6 @@ import signal
 
 import trio  # type: ignore
 
-from ._actor import Actor
 from .log import get_console_log, get_logger
 from . import _state
 
@@ -16,7 +15,7 @@ log = get_logger(__name__)
 
 
 def _mp_main(
-    actor: 'Actor',
+    actor: 'Actor',  # noqa
     accept_addr: Tuple[str, int],
     forkserver_info: Tuple[Any, Any, Any, Any, Any],
     start_method: str,
@@ -49,11 +48,13 @@ def _mp_main(
         trio.run(trio_main)
     except KeyboardInterrupt:
         pass  # handle it the same way trio does?
-    log.info(f"Actor {actor.uid} terminated")
+
+    finally:
+        log.info(f"Actor {actor.uid} terminated")
 
 
 def _trio_main(
-    actor: 'Actor',
+    actor: 'Actor',  # noqa
     parent_addr: Tuple[str, int] = None
 ) -> None:
     """Entry point for a `trio_run_in_process` subactor.
@@ -86,4 +87,5 @@ def _trio_main(
     except KeyboardInterrupt:
         log.warning(f"Actor {actor.uid} received KBI")
 
-    log.info(f"Actor {actor.uid} terminated")
+    finally:
+        log.info(f"Actor {actor.uid} terminated")


### PR DESCRIPTION
Turns out this is a lower level issue in terms of the stdlib's default
`pdb.Pdb` settings and how they conflict with `trio`s cancellation and
KBI handling. The details are hashed out more thoroughly in
python-trio/trio#1155. Maybe we can get a fix in trio so things are
solved under our feet :)