### PR TITLE
Add a way to shield a stream's underlying channel

### DIFF
--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -42,9 +42,15 @@ def mk_cmd(ex_name: str) -> str:
 
 @pytest.fixture
 def spawn(
+    start_method,
     testdir,
     arb_addr,
 ) -> 'pexpect.spawn':
+
+    if start_method != 'trio':
+        pytest.skip(
+            "Debugger tests are only supported on the trio backend"
+        )
 
     def _spawn(cmd):
         return testdir.spawn(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -7,6 +7,7 @@ import platform
 
 import trio
 import tractor
+from tractor.testing import tractor_test
 import pytest
 
 
@@ -53,6 +54,7 @@ async def stream_from_single_subactor(stream_func_name):
     """Verify we can spawn a daemon actor and retrieve streamed data.
     """
     async with tractor.find_actor('streamerd') as portals:
+
         if not portals:
             # only one per host address, spawns an actor if None
             async with tractor.open_nursery() as nursery:
@@ -73,8 +75,10 @@ async def stream_from_single_subactor(stream_func_name):
                 # it'd sure be nice to have an asyncitertools here...
                 iseq = iter(seq)
                 ival = next(iseq)
+
                 async for val in stream:
                     assert val == ival
+
                     try:
                         ival = next(iseq)
                     except StopIteration:
@@ -83,6 +87,7 @@ async def stream_from_single_subactor(stream_func_name):
                         await stream.aclose()
 
                 await trio.sleep(0.3)
+
                 try:
                     await stream.__anext__()
                 except StopAsyncIteration:
@@ -109,8 +114,11 @@ def test_stream_from_single_subactor(arb_addr, start_method, stream_func):
 
 # this is the first 2 actors, streamer_1 and streamer_2
 async def stream_data(seed):
+
     for i in range(seed):
+
         yield i
+
         # trigger scheduler to simulate practical usage
         await trio.sleep(0)
 
@@ -246,3 +254,68 @@ def test_not_fast_enough_quad(
     else:
         # should be cancelled mid-streaming
         assert results is None
+
+
+@tractor_test
+async def test_respawn_consumer_task(
+    arb_addr,
+    spawn_backend,
+    loglevel,
+):
+    """Verify that ``._portal.StreamReceiveChannel.shield_channel()``
+    sucessfully protects the underlying IPC channel from being closed
+    when cancelling and respawning a consumer task.
+
+    This also serves to verify that all values from the stream can be
+    received despite the respawns.
+
+    """
+    stream = None
+
+    async with tractor.open_nursery() as n:
+
+        stream = await(await n.run_in_actor(
+            'streamer',
+            stream_data,
+            seed=11,
+        )).result()
+
+        expect = set(range(11))
+        received = []
+
+        # this is the re-spawn task routine
+        async def consume(task_status=trio.TASK_STATUS_IGNORED):
+            print('starting consume task..')
+            nonlocal stream
+
+            with trio.CancelScope() as cs:
+                task_status.started(cs)
+
+                # shield stream's underlying channel from cancellation
+                with stream.shield_channel():
+
+                    async for v in stream:
+                        print(f'from stream: {v}')
+                        expect.remove(v)
+                        received.append(v)
+
+                print('exited consume')
+
+        async with trio.open_nursery() as ln:
+            cs = await ln.start(consume)
+
+            while True:
+
+                await trio.sleep(0.1)
+
+                if received[-1] % 2 == 0:
+
+                    print('cancelling consume task..')
+                    cs.cancel()
+
+                    # respawn
+                    cs = await ln.start(consume)
+
+                if not expect:
+                    print("all values streamed, BREAKING")
+                    break

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -262,7 +262,7 @@ async def test_respawn_consumer_task(
     spawn_backend,
     loglevel,
 ):
-    """Verify that ``._portal.StreamReceiveChannel.shield_channel()``
+    """Verify that ``._portal.ReceiveStream.shield()``
     sucessfully protects the underlying IPC channel from being closed
     when cancelling and respawning a consumer task.
 
@@ -292,7 +292,7 @@ async def test_respawn_consumer_task(
                 task_status.started(cs)
 
                 # shield stream's underlying channel from cancellation
-                with stream.shield_channel():
+                with stream.shield():
 
                     async for v in stream:
                         print(f'from stream: {v}')

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -214,9 +214,12 @@ class Channel:
                     #     # time is pointless
                     #     await self.msgstream.send(sent)
             except trio.BrokenResourceError:
+
                 if not self._autorecon:
                     raise
+
             await self.aclose()
+
             if self._autorecon:  # attempt reconnect
                 await self._reconnect()
                 continue


### PR DESCRIPTION
Add a ``tractor._portal.StreamReceiveChannel.shield_channel()`` context manager which allows for avoiding the closing of an IPC stream's underlying channel for the purposes of task re-spawning. 

Sometimes you might want to cancel a task consuming a stream but not tear down the IPC
between actors (the default). A common use can might be where the task's "setup" work might need to be redone but you want to keep the established portal / channel in tact despite the task restart.

Includes a test.

I'm still not sure on the name here..

Any opinions @salotz , @guilledk?

Note it's used inside a `with stream.<meth name>`

Short list:
- `.shield_channel()`
- `.shielded_channel()`
- `.shield()`
- just make a `bool` property `.shield` you assign manually?
- `.shield_from_close()`
- `.channel_kept_open()`
- `.channel_shielded()`

Thoughts appreciated.