### PR TITLE
Allow passing function refs to `Portal.run()`

### DIFF
--- a/examples/a_trynamic_first_scene.py
+++ b/examples/a_trynamic_first_scene.py
@@ -13,7 +13,7 @@ async def hi():
 
 async def say_hello(other_actor):
     async with tractor.wait_for_actor(other_actor) as portal:
-        return await portal.run(_this_module, 'hi')
+        return await portal.run(hi)
 
 
 async def main():
@@ -24,14 +24,14 @@ async def main():
         print("Alright... Action!")
 
         donny = await n.run_in_actor(
-            'donny',
             say_hello,
+            name='donny',
             # arguments are always named
             other_actor='gretchen',
         )
         gretchen = await n.run_in_actor(
-            'gretchen',
             say_hello,
+            name='gretchen',
             other_actor='donny',
         )
         print(await gretchen.result())

--- a/examples/actor_spawning_and_causality.py
+++ b/examples/actor_spawning_and_causality.py
@@ -2,7 +2,8 @@ import tractor
 
 
 def cellar_door():
-   return "Dang that's beautiful"
+    assert not tractor.is_root_process()
+    return "Dang that's beautiful"
 
 
 async def main():
@@ -10,7 +11,10 @@ async def main():
     """
     async with tractor.open_nursery() as n:
 
-        portal = await n.run_in_actor('some_linguist', cellar_door)
+        portal = await n.run_in_actor(
+            cellar_door,
+            name='some_linguist',
+        )
 
     # The ``async with`` will unblock here since the 'some_linguist'
     # actor has completed its main task ``cellar_door``.

--- a/examples/actor_spawning_and_causality_with_daemon.py
+++ b/examples/actor_spawning_and_causality_with_daemon.py
@@ -19,9 +19,9 @@ async def main():
             rpc_module_paths=[__name__],
         )
 
-        print(await portal.run(__name__, 'movie_theatre_question'))
+        print(await portal.run(movie_theatre_question))
         # call the subactor a 2nd time
-        print(await portal.run(__name__, 'movie_theatre_question'))
+        print(await portal.run(movie_theatre_question))
 
         # the async with will block here indefinitely waiting
         # for our actor "frank" to complete, but since it's an

--- a/examples/asynchronous_generators.py
+++ b/examples/asynchronous_generators.py
@@ -24,7 +24,7 @@ async def main():
 
             # this async for loop streams values from the above
             # async generator running in a separate process
-            async for letter in await portal.run(__name__, 'stream_forever'):
+            async for letter in await portal.run(stream_forever):
                 print(letter)
 
     # we support trio's cancellation system
@@ -33,4 +33,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    tractor.run(main, start_method='forkserver')
+    tractor.run(main)

--- a/examples/debugging/multi_daemon_subactors.py
+++ b/examples/debugging/multi_daemon_subactors.py
@@ -23,8 +23,8 @@ async def main():
         p1 = await n.start_actor('name_error', rpc_module_paths=[__name__])
 
         # retreive results
-        stream = await p0.run(__name__, 'breakpoint_forever')
-        await p1.run(__name__, 'name_error')
+        stream = await p0.run(breakpoint_forever)
+        await p1.run(name_error)
 
 
 if __name__ == '__main__':

--- a/examples/debugging/multi_nested_subactors_error_up_through_nurseries.py
+++ b/examples/debugging/multi_nested_subactors_error_up_through_nurseries.py
@@ -18,10 +18,17 @@ async def spawn_until(depth=0):
     async with tractor.open_nursery() as n:
         if depth < 1:
             # await n.run_in_actor('breakpoint_forever', breakpoint_forever)
-            await n.run_in_actor('name_error', name_error)
+            await n.run_in_actor(
+                name_error,
+                name='name_error'
+            )
         else:
             depth -= 1
-            await n.run_in_actor(f'spawn_until_{depth}', spawn_until, depth=depth)
+            await n.run_in_actor(
+                spawn_until,
+                depth=depth,
+                name=f'spawn_until_{depth}',
+            )
 
 
 async def main():
@@ -46,12 +53,20 @@ async def main():
     async with tractor.open_nursery() as n:
 
         # spawn both actors
-        portal = await n.run_in_actor('spawner0', spawn_until, depth=3)
-        portal1 = await n.run_in_actor('spawner1', spawn_until, depth=4)
+        portal = await n.run_in_actor(
+            spawn_until,
+            depth=3,
+            name='spawner0',
+        )
+        portal1 = await n.run_in_actor(
+            spawn_until,
+            depth=4,
+            name='spawner1',
+        )
 
         # gah still an issue here.
-        # await portal.result()
-        # await portal1.result()
+        await portal.result()
+        await portal1.result()
 
 
 if __name__ == '__main__':

--- a/examples/debugging/multi_subactor_root_errors.py
+++ b/examples/debugging/multi_subactor_root_errors.py
@@ -10,7 +10,10 @@ async def spawn_error():
     """"A nested nursery that triggers another ``NameError``.
     """
     async with tractor.open_nursery() as n:
-        portal = await n.run_in_actor('name_error_1', name_error)
+        portal = await n.run_in_actor(
+            name_error,
+            name='name_error_1',
+            )
         return await portal.result()
 
 
@@ -27,8 +30,14 @@ async def main():
     async with tractor.open_nursery() as n:
 
         # spawn both actors
-        portal = await n.run_in_actor('name_error', name_error)
-        portal1 = await n.run_in_actor('spawn_error', spawn_error)
+        portal = await n.run_in_actor(
+            name_error,
+            name='name_error',
+        )
+        portal1 = await n.run_in_actor(
+            spawn_error,
+            name='spawn_error',
+        )
 
         # trigger a root actor error
         assert 0

--- a/examples/debugging/multi_subactors.py
+++ b/examples/debugging/multi_subactors.py
@@ -18,7 +18,10 @@ async def spawn_error():
     """"A nested nursery that triggers another ``NameError``.
     """
     async with tractor.open_nursery() as n:
-        portal = await n.run_in_actor('name_error_1', name_error)
+        portal = await n.run_in_actor(
+            name_error,
+            name='name_error_1',
+        )
         return await portal.result()
 
 
@@ -38,9 +41,9 @@ async def main():
         # Spawn both actors, don't bother with collecting results
         # (would result in a different debugger outcome due to parent's
         # cancellation).
-        await n.run_in_actor('bp_forever', breakpoint_forever)
-        await n.run_in_actor('name_error', name_error)
-        await n.run_in_actor('spawn_error', spawn_error)
+        await n.run_in_actor(breakpoint_forever)
+        await n.run_in_actor(name_error)
+        await n.run_in_actor(spawn_error)
 
 
 if __name__ == '__main__':

--- a/examples/debugging/root_cancelled_but_child_is_in_tty_lock.py
+++ b/examples/debugging/root_cancelled_but_child_is_in_tty_lock.py
@@ -12,10 +12,14 @@ async def spawn_until(depth=0):
     async with tractor.open_nursery() as n:
         if depth < 1:
             # await n.run_in_actor('breakpoint_forever', breakpoint_forever)
-            await n.run_in_actor('name_error', name_error)
+            await n.run_in_actor(name_error)
         else:
             depth -= 1
-            await n.run_in_actor(f'spawn_until_{depth}', spawn_until, depth=depth)
+            await n.run_in_actor(
+                spawn_until,
+                depth=depth,
+                name=f'spawn_until_{depth}',
+            )
 
 
 async def main():
@@ -36,8 +40,16 @@ async def main():
     async with tractor.open_nursery() as n:
 
         # spawn both actors
-        portal = await n.run_in_actor('spawner0', spawn_until, depth=0)
-        portal1 = await n.run_in_actor('spawner1', spawn_until, depth=1)
+        portal = await n.run_in_actor(
+            spawn_until,
+            depth=0,
+            name='spawner0',
+        )
+        portal1 = await n.run_in_actor(
+            spawn_until,
+            depth=1,
+            name='spawner1',
+        )
 
         # nursery cancellation should be triggered due to propagated
         # error from child.

--- a/examples/debugging/subactor_breakpoint.py
+++ b/examples/debugging/subactor_breakpoint.py
@@ -15,7 +15,6 @@ async def main():
     async with tractor.open_nursery() as n:
 
         portal = await n.run_in_actor(
-            'breakpoint_forever',
             breakpoint_forever,
         )
         await portal.result()

--- a/examples/debugging/subactor_error.py
+++ b/examples/debugging/subactor_error.py
@@ -8,7 +8,7 @@ async def name_error():
 async def main():
     async with tractor.open_nursery() as n:
 
-        portal = await n.run_in_actor('name_error', name_error)
+        portal = await n.run_in_actor(name_error)
         await portal.result()
 
 

--- a/examples/full_fledged_streaming_service.py
+++ b/examples/full_fledged_streaming_service.py
@@ -30,9 +30,7 @@ async def aggregate(seed):
 
         async def push_to_chan(portal, send_chan):
             async with send_chan:
-                async for value in await portal.run(
-                    __name__, 'stream_data', seed=seed
-                ):
+                async for value in await portal.run(stream_data, seed=seed):
                     # leverage trio's built-in backpressure
                     await send_chan.send(value)
 
@@ -74,8 +72,8 @@ async def main():
         pre_start = time.time()
 
         portal = await nursery.run_in_actor(
-            'aggregator',
             aggregate,
+            name='aggregator',
             seed=seed,
         )
 

--- a/examples/remote_error_propagation.py
+++ b/examples/remote_error_propagation.py
@@ -15,7 +15,7 @@ async def main():
             ))
 
         # start one actor that will fail immediately
-        await n.run_in_actor('extra', assert_err)
+        await n.run_in_actor(assert_err)
 
     # should error here with a ``RemoteActorError`` containing
     # an ``AssertionError`` and all the other actors have been cancelled

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -137,7 +137,7 @@ def test_cancel_single_subactor(arb_addr, mechanism):
             portal = await nursery.start_actor(
                 'nothin', rpc_module_paths=[__name__],
             )
-            assert (await portal.run(__name__, 'do_nothing')) is None
+            assert (await portal.run(do_nothing)) is None
 
             if mechanism == 'nursery_cancel':
                 # would hang otherwise
@@ -173,7 +173,7 @@ async def test_cancel_infinite_streamer(start_method):
 
             # this async for loop streams values from the above
             # async generator running in a separate process
-            async for letter in await portal.run(__name__, 'stream_forever'):
+            async for letter in await portal.run(stream_forever):
                 print(letter)
 
     # we support trio's cancellation system
@@ -247,7 +247,8 @@ async def test_some_cancels_all(num_actors_and_errs, start_method, loglevel):
                     # if this function fails then we should error here
                     # and the nursery should teardown all other actors
                     try:
-                        await portal.run(__name__, func.__name__, **kwargs)
+                        await portal.run(func, **kwargs)
+
                     except tractor.RemoteActorError as err:
                         assert err.type == err_type
                         # we only expect this first error to propogate

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -237,7 +237,7 @@ def test_multi_subactors(spawn):
     child.expect(r"\(Pdb\+\+\)")
 
     before = str(child.before.decode())
-    assert "Attaching pdb to actor: ('bp_forever'" in before
+    assert "Attaching pdb to actor: ('breakpoint_forever'" in before
 
     # do some "next" commands to demonstrate recurrent breakpoint
     # entries
@@ -265,7 +265,7 @@ def test_multi_subactors(spawn):
     child.sendline('c')
     child.expect(r"\(Pdb\+\+\)")
     before = str(child.before.decode())
-    assert "Attaching pdb to actor: ('bp_forever'" in before
+    assert "Attaching pdb to actor: ('breakpoint_forever'" in before
 
     # now run some "continues" to show re-entries
     for _ in range(5):
@@ -277,7 +277,7 @@ def test_multi_subactors(spawn):
     child.expect(r"\(Pdb\+\+\)")
     before = str(child.before.decode())
     assert "Attaching to pdb in crashed actor: ('arbiter'" in before
-    assert "RemoteActorError: ('bp_forever'" in before
+    assert "RemoteActorError: ('breakpoint_forever'" in before
     assert 'bdb.BdbQuit' in before
 
     # process should exit
@@ -285,7 +285,7 @@ def test_multi_subactors(spawn):
     child.expect(pexpect.EOF)
 
     before = str(child.before.decode())
-    assert "RemoteActorError: ('bp_forever'" in before
+    assert "RemoteActorError: ('breakpoint_forever'" in before
     assert 'bdb.BdbQuit' in before
 
 
@@ -391,8 +391,9 @@ def test_multi_nested_subactors_error_through_nurseries(spawn):
 
     child.expect(pexpect.EOF)
 
-    before = str(child.before.decode())
-    assert "NameError" in before
+    if not timed_out_early:
+        before = str(child.before.decode())
+        assert "NameError" in before
 
 
 def test_root_nursery_cancels_before_child_releases_tty_lock(spawn, start_method):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -74,14 +74,14 @@ async def test_trynamic_trio(func, start_method):
         print("Alright... Action!")
 
         donny = await n.run_in_actor(
-            'donny',
             func,
             other_actor='gretchen',
+            name='donny',
         )
         gretchen = await n.run_in_actor(
-            'gretchen',
             func,
             other_actor='donny',
+            name='gretchen',
         )
         print(await gretchen.result())
         print(await donny.result())
@@ -147,7 +147,7 @@ async def spawn_and_check_registry(
                     portals = {}
                     for i in range(3):
                         name = f'a{i}'
-                        portals[name] = await n.run_in_actor(name, to_run)
+                        portals[name] = await n.run_in_actor(to_run, name=name)
 
                     # wait on last actor to come up
                     async with tractor.wait_for_actor(name):
@@ -257,7 +257,10 @@ async def close_chans_before_nursery(
             get_reg = partial(aportal.run, 'self', 'get_registry')
 
             async with tractor.open_nursery() as tn:
-                portal1 = await tn.run_in_actor('consumer1', stream_forever)
+                portal1 = await tn.run_in_actor(
+                    stream_forever,
+                    name='consumer1',
+                )
                 agen1 = await portal1.result()
 
                 portal2 = await tn.start_actor('consumer2', rpc_module_paths=[__name__])

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -46,7 +46,7 @@ async def test_self_is_registered_localportal(arb_addr):
     assert actor.is_arbiter
     async with tractor.get_arbiter(*arb_addr) as portal:
         assert isinstance(portal, tractor._portal.LocalPortal)
-        sockaddr = await portal.run('self', 'wait_for_actor', name='arbiter')
+        sockaddr = await portal.run_from_ns('self', 'wait_for_actor', name='arbiter')
         assert sockaddr[0] == arb_addr
 
 

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -126,7 +126,10 @@ async def test_required_args(callwith_expecterror):
         async with tractor.open_nursery() as n:
             # await func(**kwargs)
             portal = await n.run_in_actor(
-                'pubber', multilock_pubber, **kwargs)
+                multilock_pubber,
+                name='pubber',
+                **kwargs
+            )
 
             async with tractor.wait_for_actor('pubber'):
                 pass
@@ -163,9 +166,17 @@ def test_multi_actor_subs_arbiter_pub(
                 )
 
             even_portal = await n.run_in_actor(
-                'evens', subs, which=['even'], pub_actor_name=name)
+                subs,
+                which=['even'],
+                name='evens',
+                pub_actor_name=name
+            )
             odd_portal = await n.run_in_actor(
-                'odds', subs, which=['odd'], pub_actor_name=name)
+                subs,
+                which=['odd'],
+                name='odds',
+                pub_actor_name=name
+            )
 
             async with tractor.wait_for_actor('evens'):
                 # block until 2nd actor is initialized

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -58,7 +58,7 @@ async def subs(
 
     async with tractor.find_actor(pub_actor_name) as portal:
         stream = await portal.run(
-            __name__, 'pubber',
+            pubber,
             topics=which,
             seed=seed,
         )
@@ -76,7 +76,7 @@ async def subs(
         await stream.aclose()
 
         stream = await portal.run(
-            __name__, 'pubber',
+            pubber,
             topics=['odd'],
             seed=seed,
         )

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -80,9 +80,11 @@ def test_rpc_errors(arb_addr, to_call, testdir):
         # spawn a subactor which calls us back
         async with tractor.open_nursery() as n:
             await n.run_in_actor(
-                'subactor',
                 sleep_back_actor,
                 actor_name=subactor_requests_to,
+
+                name='subactor',
+
                 # function from the local exposed module space
                 # the subactor will invoke when it RPCs back to this actor
                 func_name=funcname,

--- a/tests/test_spawning.py
+++ b/tests/test_spawning.py
@@ -70,9 +70,9 @@ async def test_movie_theatre_convo(start_method):
             rpc_module_paths=[__name__],
         )
 
-        print(await portal.run(__name__, 'movie_theatre_question'))
+        print(await portal.run(movie_theatre_question))
         # call the subactor a 2nd time
-        print(await portal.run(__name__, 'movie_theatre_question'))
+        print(await portal.run(movie_theatre_question))
 
         # the async with will block here indefinitely waiting
         # for our actor "frank" to complete, we cancel 'frank'

--- a/tests/test_spawning.py
+++ b/tests/test_spawning.py
@@ -1,31 +1,33 @@
 """
 Spawning basics
 """
+from functools import partial
+
 import pytest
 import trio
 import tractor
 
 from conftest import tractor_test
 
-statespace = {'doggy': 10, 'kitty': 4}
+data_to_pass_down = {'doggy': 10, 'kitty': 4}
 
 
-async def spawn(is_arbiter):
+async def spawn(is_arbiter, data):
     namespaces = [__name__]
 
     await trio.sleep(0.1)
     actor = tractor.current_actor()
     assert actor.is_arbiter == is_arbiter
-    assert actor.statespace == statespace
+    data == data_to_pass_down
 
     if actor.is_arbiter:
         async with tractor.open_nursery() as nursery:
             # forks here
             portal = await nursery.run_in_actor(
-                'sub-actor',
                 spawn,
                 is_arbiter=False,
-                statespace=statespace,
+                name='sub-actor',
+                data=data,
                 rpc_module_paths=namespaces,
             )
 
@@ -41,10 +43,9 @@ async def spawn(is_arbiter):
 
 def test_local_arbiter_subactor_global_state(arb_addr):
     result = tractor.run(
-        spawn,
+        partial(spawn, data=data_to_pass_down),
         True,
         name='arbiter',
-        statespace=statespace,
         arbiter_addr=arb_addr,
     )
     assert result == 10
@@ -89,7 +90,10 @@ async def test_most_beautiful_word(start_method):
     """
     async with tractor.open_nursery() as n:
 
-        portal = await n.run_in_actor('some_linguist', cellar_door)
+        portal = await n.run_in_actor(
+            cellar_door,
+            name='some_linguist',
+        )
 
     # The ``async with`` will unblock here since the 'some_linguist'
     # actor has completed its main task ``cellar_door``.
@@ -119,7 +123,6 @@ def test_loglevel_propagated_to_subactor(
     async def main():
         async with tractor.open_nursery() as tn:
             await tn.run_in_actor(
-                'log_checker',
                 check_loglevel,
                 level=level,
             )

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -50,7 +50,7 @@ async def context_stream(ctx, sequence):
     assert cs.cancelled_caught
 
 
-async def stream_from_single_subactor(stream_func_name):
+async def stream_from_single_subactor(stream_func):
     """Verify we can spawn a daemon actor and retrieve streamed data.
     """
     async with tractor.find_actor('streamerd') as portals:
@@ -67,8 +67,7 @@ async def stream_from_single_subactor(stream_func_name):
                 seq = range(10)
 
                 stream = await portal.run(
-                    __name__,
-                    stream_func_name,  # one of the funcs above
+                    stream_func,  # one of the funcs above
                     sequence=list(seq),  # has to be msgpack serializable
                 )
                 # it'd sure be nice to have an asyncitertools here...
@@ -96,7 +95,7 @@ async def stream_from_single_subactor(stream_func_name):
 
 
 @pytest.mark.parametrize(
-    'stream_func', ['async_gen_stream', 'context_stream']
+    'stream_func', [async_gen_stream, context_stream]
 )
 def test_stream_from_single_subactor(arb_addr, start_method, stream_func):
     """Verify streaming from a spawned async generator.
@@ -104,7 +103,7 @@ def test_stream_from_single_subactor(arb_addr, start_method, stream_func):
     tractor.run(
         partial(
             stream_from_single_subactor,
-            stream_func_name=stream_func,
+            stream_func=stream_func,
         ),
         arbiter_addr=arb_addr,
         start_method=start_method,

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -62,7 +62,6 @@ async def stream_from_single_subactor(stream_func_name):
                 portal = await nursery.start_actor(
                     'streamerd',
                     rpc_module_paths=[__name__],
-                    statespace={'global_dict': {}},
                 )
 
                 seq = range(10)
@@ -186,9 +185,9 @@ async def a_quadruple_example():
         pre_start = time.time()
 
         portal = await nursery.run_in_actor(
-            'aggregator',
             aggregate,
             seed=seed,
+            name='aggregator',
         )
 
         start = time.time()
@@ -275,9 +274,9 @@ async def test_respawn_consumer_task(
     async with tractor.open_nursery() as n:
 
         stream = await(await n.run_in_actor(
-            'streamer',
             stream_data,
             seed=11,
+            name='streamer',
         )).result()
 
         expect = set(range(11))

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -16,7 +16,7 @@ from ._streaming import Context, stream
 from ._discovery import get_arbiter, find_actor, wait_for_actor
 from ._actor import Actor, _start_actor, Arbiter
 from ._trionics import open_nursery
-from ._state import current_actor
+from ._state import current_actor, is_root_process
 from . import _state
 from ._exceptions import RemoteActorError, ModuleNotExposed
 from ._debug import breakpoint, post_mortem

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -194,7 +194,6 @@ class Actor:
         name: str,
         *,
         rpc_module_paths: List[str] = [],
-        statespace: Optional[Dict[str, Any]] = None,
         uid: str = None,
         loglevel: str = None,
         arbiter_addr: Optional[Tuple[str, int]] = None,
@@ -226,7 +225,6 @@ class Actor:
 
         # TODO: consider making this a dynamically defined
         # @dataclass once we get py3.7
-        self.statespace = statespace or {}
         self.loglevel = loglevel
         self._arb_addr = arbiter_addr
 

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -712,7 +712,7 @@ class Actor:
                     assert isinstance(self._arb_addr, tuple)
 
                     async with get_arbiter(*self._arb_addr) as arb_portal:
-                        await arb_portal.run(
+                        await arb_portal.run_from_ns(
                             'self',
                             'register_actor',
                             uid=self.uid,
@@ -788,8 +788,11 @@ class Actor:
                     cs.shield = True
                     try:
                         async with get_arbiter(*self._arb_addr) as arb_portal:
-                            await arb_portal.run(
-                                'self', 'unregister_actor', uid=self.uid)
+                            await arb_portal.run_from_ns(
+                                'self',
+                                'unregister_actor',
+                                uid=self.uid
+                            )
                     except OSError:
                         failed = True
                 if cs.cancelled_caught:

--- a/tractor/_debug.py
+++ b/tractor/_debug.py
@@ -305,6 +305,10 @@ post_mortem = partial(
 async def _maybe_enter_pm(err):
     if (
         _state.debug_mode()
+
+        # NOTE: don't enter debug mode recursively after quitting pdb
+        # Iow, don't re-enter the repl if the `quit` command was issued
+        # by the user.
         and not isinstance(err, bdb.BdbQuit)
 
         # XXX: if the error is the likely result of runtime-wide

--- a/tractor/_debug.py
+++ b/tractor/_debug.py
@@ -180,15 +180,14 @@ def _breakpoint(debug_func) -> Awaitable[None]:
             try:
                 async with get_root() as portal:
                     with trio.fail_after(.5):
-                        agen = await portal.run(
-                            'tractor._debug',
-                            '_hijack_stdin_relay_to_child',
+                        stream = await portal.run(
+                            tractor._debug._hijack_stdin_relay_to_child,
                             subactor_uid=actor.uid,
                         )
-                    async with aclosing(agen):
+                    async with aclosing(stream):
 
                         # block until first yield above
-                        async for val in agen:
+                        async for val in stream:
 
                             assert val == 'Locked'
                             task_status.started()

--- a/tractor/_discovery.py
+++ b/tractor/_discovery.py
@@ -60,7 +60,7 @@ async def find_actor(
     """
     actor = current_actor()
     async with get_arbiter(*arbiter_sockaddr or actor._arb_addr) as arb_portal:
-        sockaddr = await arb_portal.run('self', 'find_actor', name=name)
+        sockaddr = await arb_portal.run_from_ns('self', 'find_actor', name=name)
         # TODO: return portals to all available actors - for now just
         # the last one that registered
         if name == 'arbiter' and actor.is_arbiter:
@@ -84,7 +84,7 @@ async def wait_for_actor(
     """
     actor = current_actor()
     async with get_arbiter(*arbiter_sockaddr or actor._arb_addr) as arb_portal:
-        sockaddrs = await arb_portal.run('self', 'wait_for_actor', name=name)
+        sockaddrs = await arb_portal.run_from_ns('self', 'wait_for_actor', name=name)
         sockaddr = sockaddrs[-1]
         async with _connect_chan(*sockaddr) as chan:
             async with open_portal(chan) as portal:

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -248,7 +248,6 @@ async def new_proc(
                 await chan.send({
                     "_parent_main_data": subactor._parent_main_data,
                     "rpc_module_paths": subactor.rpc_module_paths,
-                    "statespace": subactor.statespace,
                     "_arb_addr": subactor._arb_addr,
                     "bind_host": bind_addr[0],
                     "bind_port": bind_addr[1],

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -52,7 +52,7 @@ class ActorNursery:
         name: str,
         *,
         bind_addr: Tuple[str, int] = _default_bind_addr,
-        statespace: Optional[Dict[str, Any]] = None,
+        # statespace: Optional[Dict[str, Any]] = None,
         rpc_module_paths: List[str] = None,
         loglevel: str = None,  # set log level per subactor
         nursery: trio.Nursery = None,
@@ -67,7 +67,7 @@ class ActorNursery:
             name,
             # modules allowed to invoked funcs from
             rpc_module_paths=rpc_module_paths or [],
-            statespace=statespace,  # global proc state vars
+            # statespace=statespace,  # global proc state vars
             loglevel=loglevel,
             arbiter_addr=current_actor()._arb_addr,
         )
@@ -94,12 +94,12 @@ class ActorNursery:
 
     async def run_in_actor(
         self,
-        name: str,
         fn: typing.Callable,
         *,
+        name: Optional[str] = None,
         bind_addr: Tuple[str, int] = _default_bind_addr,
         rpc_module_paths: Optional[List[str]] = None,
-        statespace: Dict[str, Any] = None,
+        # statespace: Dict[str, Any] = None,
         loglevel: str = None,  # set log level per subactor
         **kwargs,  # explicit args to ``fn``
     ) -> Portal:
@@ -111,11 +111,16 @@ class ActorNursery:
         the actor is terminated.
         """
         mod_path = fn.__module__
+
+        if name is None:
+            # use the explicit function name if not provided
+            name = fn.__name__
+
         portal = await self.start_actor(
             name,
             rpc_module_paths=[mod_path] + (rpc_module_paths or []),
             bind_addr=bind_addr,
-            statespace=statespace,
+            # statespace=statespace,
             loglevel=loglevel,
             # use the run_in_actor nursery
             nursery=self._ria_nursery,

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -52,7 +52,6 @@ class ActorNursery:
         name: str,
         *,
         bind_addr: Tuple[str, int] = _default_bind_addr,
-        # statespace: Optional[Dict[str, Any]] = None,
         rpc_module_paths: List[str] = None,
         loglevel: str = None,  # set log level per subactor
         nursery: trio.Nursery = None,
@@ -67,7 +66,6 @@ class ActorNursery:
             name,
             # modules allowed to invoked funcs from
             rpc_module_paths=rpc_module_paths or [],
-            # statespace=statespace,  # global proc state vars
             loglevel=loglevel,
             arbiter_addr=current_actor()._arb_addr,
         )
@@ -99,7 +97,6 @@ class ActorNursery:
         name: Optional[str] = None,
         bind_addr: Tuple[str, int] = _default_bind_addr,
         rpc_module_paths: Optional[List[str]] = None,
-        # statespace: Dict[str, Any] = None,
         loglevel: str = None,  # set log level per subactor
         **kwargs,  # explicit args to ``fn``
     ) -> Portal:
@@ -120,7 +117,6 @@ class ActorNursery:
             name,
             rpc_module_paths=[mod_path] + (rpc_module_paths or []),
             bind_addr=bind_addr,
-            # statespace=statespace,
             loglevel=loglevel,
             # use the run_in_actor nursery
             nursery=self._ria_nursery,


### PR DESCRIPTION
This resolves and completes #69 allowing all RPC invocation APIs to pass
function references directly instead of explicit `str` names for the
target namespace and function (this is still done implicitly
underneath).  This brings us closer to `trio`'s task running API as well
as acknowledges that any inter-host RPC system (and API) will likely
need to be implemented on top of local RPC primitives anyway. Even if
this ends up **not** being true we can always go to "function stubs" as
part of our IAC protocol or, add a new method to do explicit namespace
calls: `.run_from_module()` or whatever everyone votes on.

Resolves #69

Further, this commit drops `Actor.statespace` from the entire system
since a user can easily get this same functionality using module
level variables. Fix docs to match all these changes (luckily mostly
already done due to example scripts referencing).