### PR TITLE
Denoise logging

### DIFF
--- a/examples/debugging/multi_subactor_root_errors.py
+++ b/examples/debugging/multi_subactor_root_errors.py
@@ -26,6 +26,11 @@ async def main():
     ├─ python -m tractor._child --uid ('name_error', 'a7caf490 ...)
     `-python -m tractor._child --uid ('spawn_error', '52ee14a5 ...)
        `-python -m tractor._child --uid ('name_error', '3391222c ...)
+
+    Order of failure:
+        - nested name_error sub-sub-actor
+        - root actor should then fail on assert
+        - program termination
     """
     async with tractor.open_nursery() as n:
 

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -343,10 +343,13 @@ def test_multi_subactors_root_errors(spawn):
 
     # should now get attached in root with assert error
     before = str(child.before.decode())
+
     # should have come just after priot prompt
-    assert "Cancelling nursery in ('spawn_error'," in before
     assert "Attaching to pdb in crashed actor: ('arbiter'" in before
     assert "AssertionError" in before
+
+    # warnings assert we probably don't need
+    # assert "Cancelling nursery in ('spawn_error'," in before
 
     # continue again
     child.sendline('c')
@@ -368,6 +371,9 @@ def test_multi_nested_subactors_error_through_nurseries(spawn):
     # fixed.
 
     child = spawn('multi_nested_subactors_error_up_through_nurseries')
+
+    # startup time can be iffy
+    time.sleep(1)
 
     for i in range(12):
         try:

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -25,7 +25,8 @@ from .log import get_logger
 from ._exceptions import (
     pack_error,
     unpack_error,
-    ModuleNotExposed
+    ModuleNotExposed,
+    is_multi_cancelled,
 )
 from . import _debug
 from ._discovery import get_arbiter
@@ -129,7 +130,11 @@ async def _invoke(
 
     except (Exception, trio.MultiError) as err:
 
-        if not isinstance(err, trio.ClosedResourceError):
+        # TODO: maybe we'll want differnet "levels" of debugging
+        # eventualy such as ('app', 'supervisory', 'runtime') ?
+        if not isinstance(err, trio.ClosedResourceError) and (
+            not is_multi_cancelled(err)
+        ):
             log.exception("Actor crashed:")
             # XXX: is there any case where we'll want to debug IPC
             # disconnects? I can't think of a reason that inspecting

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -144,7 +144,7 @@ async def _invoke(
         try:
             await chan.send(err_msg)
         except trio.ClosedResourceError:
-            log.exception(
+            log.warning(
                 f"Failed to ship error to caller @ {chan.uid}")
         if cs is None:
             # error is from above code not from rpc invocation

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -135,13 +135,14 @@ async def _invoke(
         if not isinstance(err, trio.ClosedResourceError) and (
             not is_multi_cancelled(err)
         ):
-            log.exception("Actor crashed:")
             # XXX: is there any case where we'll want to debug IPC
             # disconnects? I can't think of a reason that inspecting
             # this type of failure will be useful for respawns or
             # recovery logic - the only case is some kind of strange bug
             # in `trio` itself?
-            await _debug._maybe_enter_pm(err)
+            entered = await _debug._maybe_enter_pm(err)
+            if not entered:
+                log.exception("Actor crashed:")
 
         # always ship errors back to caller
         err_msg = pack_error(err)

--- a/tractor/_debug.py
+++ b/tractor/_debug.py
@@ -15,6 +15,7 @@ from .log import get_logger
 from . import _state
 from ._discovery import get_root
 from ._state import is_root_process
+from ._exceptions import is_multi_cancelled
 
 try:
     # wtf: only exported when installed in dev mode?
@@ -318,10 +319,7 @@ async def _maybe_enter_pm(err):
 
         # Really we just want to mostly avoid catching KBIs here so there
         # might be a simpler check we can do?
-        and trio.MultiError.filter(
-            lambda exc: exc if not isinstance(exc, trio.Cancelled) else None,
-            err,
-        )
+        and not is_multi_cancelled(err)
     ):
         log.warning("Actor crashed, entering debug mode")
         await post_mortem()

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -51,7 +51,7 @@ class MsgpackStream:
                 data = await self.stream.receive_some(2**10)
                 log.trace(f"received {data}")  # type: ignore
             except trio.BrokenResourceError:
-                log.error(f"Stream connection {self.raddr} broke")
+                log.warning(f"Stream connection {self.raddr} broke")
                 return
 
             if data == b'':

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -13,6 +13,7 @@ from ._state import current_actor
 from .log import get_logger, get_loglevel
 from ._actor import Actor
 from ._portal import Portal
+from ._exceptions import is_multi_cancelled
 from . import _state
 from . import _spawn
 
@@ -246,7 +247,9 @@ async def open_nursery() -> typing.AsyncGenerator[ActorNursery, None]:
                         # For now, shield both.
                         with trio.CancelScope(shield=True):
                             etype = type(err)
-                            if etype in (trio.Cancelled, KeyboardInterrupt):
+                            if etype in (trio.Cancelled, KeyboardInterrupt) or (
+                                is_multi_cancelled(err)
+                            ):
                                 log.warning(
                                     f"Nursery for {current_actor().uid} was "
                                     f"cancelled with {etype}")

--- a/tractor/log.py
+++ b/tractor/log.py
@@ -31,11 +31,13 @@ LEVELS = {
     'GARBAGE': 1,
     'TRACE': 5,
     'PROFILE': 15,
+    'RUNTIME': 500,
     'QUIET': 1000,
 }
 STD_PALETTE = {
     'CRITICAL': 'red',
     'ERROR': 'red',
+    'RUNTIME': 'white',
     'WARNING': 'yellow',
     'INFO': 'green',
     'DEBUG': 'white',

--- a/tractor/log.py
+++ b/tractor/log.py
@@ -11,7 +11,7 @@ from ._state import ActorContextInfo
 
 
 _proj_name = 'tractor'
-_default_loglevel = None
+_default_loglevel = 'ERROR'
 
 # Super sexy formatting thanks to ``colorlog``.
 # (NOTE: we use the '{' format style)


### PR DESCRIPTION
Some minimal effort to reduce `error` logging to warnings.
Change default logging level to `error` to aid with this.