### PR TITLE
Drop run

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -145,7 +145,7 @@ and use the ``run_in_actor()`` method:
 
 What's going on?
 
-- an initial *actor* is started with ``tractor.run()`` and told to execute
+- an initial *actor* is started with ``trio.run()`` and told to execute
   its main task_: ``main()``
 
 - inside ``main()`` an actor is *spawned* using an ``ActorNusery`` and is told
@@ -458,7 +458,7 @@ find an actor's socket address by name use the ``find_actor()`` function:
 .. literalinclude:: ../examples/service_discovery.py
 
 The ``name`` value you should pass to ``find_actor()`` is the one you passed as the
-*first* argument to either ``tractor.run()`` or ``ActorNursery.start_actor()``.
+*first* argument to either ``trio.run()`` or ``ActorNursery.start_actor()``.
 
 
 Running actors standalone
@@ -472,7 +472,17 @@ need to hop into a debugger. You just need to pass the existing
 
 .. code:: python
 
-    tractor.run(main, arbiter_addr=('192.168.0.10', 1616))
+    import trio
+    import tractor
+
+    async def main():
+
+        async with tractor.open_root_actor(
+            arbiter_addr=('192.168.0.10', 1616)
+        ):
+            await trio.sleep_forever()
+
+    trio.run(main)
 
 
 Choosing a process spawning backend
@@ -480,7 +490,7 @@ Choosing a process spawning backend
 ``tractor`` is architected to support multiple actor (sub-process)
 spawning backends. Specific defaults are chosen based on your system
 but you can also explicitly select a backend of choice at startup
-via a ``start_method`` kwarg to ``tractor.run()``.
+via a ``start_method`` kwarg to ``tractor.open_nursery()``.
 
 Currently the options available are:
 
@@ -536,13 +546,14 @@ main python module of the program:
 .. code:: python
 
     # application/__main__.py
+    import trio
     import tractor
     import multiprocessing
     from . import tractor_app
 
     if __name__ == '__main__':
         multiprocessing.freeze_support()
-        tractor.run(tractor_app.main)
+        trio.run(tractor_app.main)
 
 And execute as::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -182,7 +182,7 @@ Here is a similar example using the latter method:
 
 .. literalinclude:: ../examples/actor_spawning_and_causality_with_daemon.py
 
-The ``rpc_module_paths`` `kwarg` above is a list of module path
+The ``enable_modules`` `kwarg` above is a list of module path
 strings that will be loaded and made accessible for execution in the
 remote actor through a call to ``Portal.run()``. For now this is
 a simple mechanism to restrict the functionality of the remote

--- a/examples/__main__.py
+++ b/examples/__main__.py
@@ -16,4 +16,4 @@ if __name__ == '__main__':
     # temporary dir and name it test_example.py. We import that script
     # module here and invoke it's ``main()``.
     from . import test_example
-    test_example.tractor.run(test_example.main, start_method='spawn')
+    test_example.trio.run(test_example.main)

--- a/examples/a_trynamic_first_scene.py
+++ b/examples/a_trynamic_first_scene.py
@@ -1,3 +1,4 @@
+import trio
 import tractor
 
 _this_module = __name__
@@ -40,4 +41,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    tractor.run(main)
+    trio.run(main)

--- a/examples/actor_spawning_and_causality.py
+++ b/examples/actor_spawning_and_causality.py
@@ -1,3 +1,4 @@
+import trio
 import tractor
 
 
@@ -23,4 +24,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    tractor.run(main)
+    trio.run(main)

--- a/examples/actor_spawning_and_causality_with_daemon.py
+++ b/examples/actor_spawning_and_causality_with_daemon.py
@@ -1,3 +1,4 @@
+import trio
 import tractor
 
 
@@ -30,4 +31,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    tractor.run(main)
+    trio.run(main)

--- a/examples/actor_spawning_and_causality_with_daemon.py
+++ b/examples/actor_spawning_and_causality_with_daemon.py
@@ -17,7 +17,7 @@ async def main():
         portal = await n.start_actor(
             'frank',
             # enable the actor to run funcs from this current module
-            rpc_module_paths=[__name__],
+            enable_modules=[__name__],
         )
 
         print(await portal.run(movie_theatre_question))

--- a/examples/asynchronous_generators.py
+++ b/examples/asynchronous_generators.py
@@ -22,7 +22,7 @@ async def main():
 
             portal = await n.start_actor(
                 'donny',
-                rpc_module_paths=[__name__],
+                enable_modules=[__name__],
             )
 
             # this async for loop streams values from the above

--- a/examples/asynchronous_generators.py
+++ b/examples/asynchronous_generators.py
@@ -14,11 +14,14 @@ async def stream_forever():
 
 
 async def main():
+
     # stream for at most 1 seconds
     with trio.move_on_after(1) as cancel_scope:
+
         async with tractor.open_nursery() as n:
+
             portal = await n.start_actor(
-                f'donny',
+                'donny',
                 rpc_module_paths=[__name__],
             )
 
@@ -34,4 +37,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    tractor.run(main)
+    trio.run(main)

--- a/examples/debugging/multi_daemon_subactors.py
+++ b/examples/debugging/multi_daemon_subactors.py
@@ -11,7 +11,7 @@ async def breakpoint_forever():
 
 async def name_error():
     "Raise a ``NameError``"
-    getattr(doggypants)
+    getattr(doggypants)  # noqa
 
 
 async def main():

--- a/examples/debugging/multi_nested_subactors_error_up_through_nurseries.py
+++ b/examples/debugging/multi_nested_subactors_error_up_through_nurseries.py
@@ -4,7 +4,7 @@ import tractor
 
 async def name_error():
     "Raise a ``NameError``"
-    getattr(doggypants)
+    getattr(doggypants)  # noqa
 
 
 async def breakpoint_forever():

--- a/examples/debugging/multi_subactor_root_errors.py
+++ b/examples/debugging/multi_subactor_root_errors.py
@@ -1,9 +1,10 @@
+import trio
 import tractor
 
 
 async def name_error():
     "Raise a ``NameError``"
-    getattr(doggypants)
+    getattr(doggypants)  # noqa
 
 
 async def spawn_error():
@@ -32,7 +33,9 @@ async def main():
         - root actor should then fail on assert
         - program termination
     """
-    async with tractor.open_nursery() as n:
+    async with tractor.open_nursery(
+        debug_mode=True,
+    ) as n:
 
         # spawn both actors
         portal = await n.run_in_actor(
@@ -54,4 +57,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    tractor.run(main, debug_mode=True)
+    trio.run(main)

--- a/examples/debugging/multi_subactors.py
+++ b/examples/debugging/multi_subactors.py
@@ -11,7 +11,7 @@ async def breakpoint_forever():
 
 async def name_error():
     "Raise a ``NameError``"
-    getattr(doggypants)
+    getattr(doggypants)  # noqa
 
 
 async def spawn_error():
@@ -36,7 +36,9 @@ async def main():
     `-python -m tractor._child --uid ('spawn_error', '52ee14a5 ...)
        `-python -m tractor._child --uid ('name_error', '3391222c ...)
     """
-    async with tractor.open_nursery() as n:
+    async with tractor.open_nursery(
+        debug_mode=True,
+    ) as n:
 
         # Spawn both actors, don't bother with collecting results
         # (would result in a different debugger outcome due to parent's
@@ -47,4 +49,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    tractor.run(main, debug_mode=True)
+    trio.run(main)

--- a/examples/debugging/root_actor_breakpoint.py
+++ b/examples/debugging/root_actor_breakpoint.py
@@ -4,12 +4,16 @@ import tractor
 
 async def main():
 
-    await trio.sleep(0.1)
+    async with tractor.open_root_actor(
+        debug_mode=True,
+    ):
 
-    await tractor.breakpoint()
+        await trio.sleep(0.1)
 
-    await trio.sleep(0.1)
+        await tractor.breakpoint()
+
+        await trio.sleep(0.1)
 
 
 if __name__ == '__main__':
-    tractor.run(main, debug_mode=True)
+    trio.run(main)

--- a/examples/debugging/root_actor_breakpoint_forever.py
+++ b/examples/debugging/root_actor_breakpoint_forever.py
@@ -1,11 +1,15 @@
+import trio
 import tractor
 
 
 async def main():
 
-    while True:
-        await tractor.breakpoint()
+    async with tractor.open_root_actor(
+        debug_mode=True,
+    ):
+        while True:
+            await tractor.breakpoint()
 
 
 if __name__ == '__main__':
-    tractor.run(main, debug_mode=True)
+    trio.run(main)

--- a/examples/debugging/root_actor_error.py
+++ b/examples/debugging/root_actor_error.py
@@ -1,9 +1,13 @@
+import trio
 import tractor
 
 
 async def main():
-    assert 0
+    async with tractor.open_root_actor(
+        debug_mode=True,
+    ):
+        assert 0
 
 
 if __name__ == '__main__':
-    tractor.run(main, debug_mode=True)
+    trio.run(main)

--- a/examples/debugging/root_cancelled_but_child_is_in_tty_lock.py
+++ b/examples/debugging/root_cancelled_but_child_is_in_tty_lock.py
@@ -1,9 +1,10 @@
+import trio
 import tractor
 
 
 async def name_error():
     "Raise a ``NameError``"
-    getattr(doggypants)
+    getattr(doggypants)  # noqa
 
 
 async def spawn_until(depth=0):
@@ -37,7 +38,10 @@ async def main():
        └─ python -m tractor._child --uid ('name_error', '6c2733b8 ...)
 
     """
-    async with tractor.open_nursery() as n:
+    async with tractor.open_nursery(
+        debug_mode=True,
+        loglevel='warning'
+    ) as n:
 
         # spawn both actors
         portal = await n.run_in_actor(
@@ -58,4 +62,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    tractor.run(main, debug_mode=True, loglevel='warning')
+    trio.run(main)

--- a/examples/debugging/subactor_breakpoint.py
+++ b/examples/debugging/subactor_breakpoint.py
@@ -12,7 +12,9 @@ async def breakpoint_forever():
 
 async def main():
 
-    async with tractor.open_nursery() as n:
+    async with tractor.open_nursery(
+        debug_mode=True,
+    ) as n:
 
         portal = await n.run_in_actor(
             breakpoint_forever,
@@ -21,4 +23,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    tractor.run(main, debug_mode=True, loglevel='debug')
+    trio.run(main)

--- a/examples/debugging/subactor_error.py
+++ b/examples/debugging/subactor_error.py
@@ -1,3 +1,4 @@
+import trio
 import tractor
 
 
@@ -6,11 +7,13 @@ async def name_error():
 
 
 async def main():
-    async with tractor.open_nursery() as n:
+    async with tractor.open_nursery(
+        debug_mode=True,
+    ) as n:
 
         portal = await n.run_in_actor(name_error)
         await portal.result()
 
 
 if __name__ == '__main__':
-    tractor.run(main, debug_mode=True)
+    trio.run(main)

--- a/examples/full_fledged_streaming_service.py
+++ b/examples/full_fledged_streaming_service.py
@@ -68,10 +68,11 @@ async def aggregate(seed):
 # this is the main actor and *arbiter*
 async def main():
     # a nursery which spawns "actors"
-    async with tractor.open_nursery() as nursery:
+    async with tractor.open_nursery(
+        arbiter_addr=('127.0.0.1', 1616)
+    ) as nursery:
 
         seed = int(1e3)
-        import time
         pre_start = time.time()
 
         portal = await nursery.start_actor(
@@ -100,4 +101,4 @@ async def main():
 
 
 if __name__ == '__main__':
-    final_stream = tractor.run(main, arbiter_addr=('127.0.0.1', 1616))
+    final_stream = trio.run(main)

--- a/examples/parallelism/_concurrent_futures_primes.py
+++ b/examples/parallelism/_concurrent_futures_primes.py
@@ -10,6 +10,7 @@ PRIMES = [
     115797848077099,
     1099726899285419]
 
+
 def is_prime(n):
     if n < 2:
         return False
@@ -24,6 +25,7 @@ def is_prime(n):
             return False
     return True
 
+
 def main():
     with concurrent.futures.ProcessPoolExecutor() as executor:
         start = time.time()
@@ -32,6 +34,7 @@ def main():
             print('%d is prime: %s' % (number, prime))
 
         print(f'processing took {time.time() - start} seconds')
+
 
 if __name__ == '__main__':
 

--- a/examples/parallelism/concurrent_actors_primes.py
+++ b/examples/parallelism/concurrent_actors_primes.py
@@ -4,7 +4,7 @@ Demonstration of the prime number detector example from the
 
 https://docs.python.org/3/library/concurrent.futures.html#processpoolexecutor-example
 
-This uses no extra threads, fancy semaphores or futures; all we need 
+This uses no extra threads, fancy semaphores or futures; all we need
 is ``tractor``'s channels.
 
 """

--- a/examples/remote_error_propagation.py
+++ b/examples/remote_error_propagation.py
@@ -12,7 +12,7 @@ async def main():
         for i in range(3):
             real_actors.append(await n.start_actor(
                 f'actor_{i}',
-                rpc_module_paths=[__name__],
+                enable_modules=[__name__],
             ))
 
         # start one actor that will fail immediately

--- a/examples/remote_error_propagation.py
+++ b/examples/remote_error_propagation.py
@@ -1,3 +1,4 @@
+import trio
 import tractor
 
 
@@ -24,6 +25,6 @@ async def main():
 if __name__ == '__main__':
     try:
         # also raises
-        tractor.run(main)
+        trio.run(main)
     except tractor.RemoteActorError:
         print("Look Maa that actor failed hard, hehhh!")

--- a/examples/service_discovery.py
+++ b/examples/service_discovery.py
@@ -1,6 +1,8 @@
+import trio
 import tractor
 
 tractor.log.get_console_log("INFO")
+
 
 async def main(service_name):
 
@@ -17,4 +19,4 @@ async def main(service_name):
 
 
 if __name__ == '__main__':
-    tractor.run(main, 'some_actor_name')
+    trio.run(main, 'some_actor_name')

--- a/tests/test_multi_program.py
+++ b/tests/test_multi_program.py
@@ -1,10 +1,11 @@
 """
-Multiple python programs invoking ``tractor.run()``
+Multiple python programs invoking the runtime.
 """
 import platform
 import time
 
 import pytest
+import trio
 import tractor
 from conftest import (
     tractor_test,
@@ -45,8 +46,13 @@ async def test_cancel_remote_arbiter(daemon, arb_addr):
 def test_register_duplicate_name(daemon, arb_addr):
 
     async def main():
-        assert not tractor.current_actor().is_arbiter
-        async with tractor.open_nursery() as n:
+
+        async with tractor.open_nursery(
+            arbiter_addr=arb_addr,
+        ) as n:
+
+            assert not tractor.current_actor().is_arbiter
+
             p1 = await n.start_actor('doggy')
             p2 = await n.start_actor('doggy')
 
@@ -57,4 +63,4 @@ def test_register_duplicate_name(daemon, arb_addr):
 
     # run it manually since we want to start **after**
     # the other "daemon" program
-    tractor.run(main, arbiter_addr=arb_addr)
+    trio.run(main)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -238,7 +238,6 @@ def test_multi_actor_subs_arbiter_pub(
                 assert 'even' not in get_topics()
 
             await odd_portal.cancel_actor()
-            await trio.sleep(2)
 
             if pub_actor == 'arbiter':
                 while get_topics():

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -170,7 +170,6 @@ def test_multi_actor_subs_arbiter_pub(
         async with tractor.open_nursery(
             arbiter_addr=arb_addr,
             enable_modules=[__name__],
-            debug_mode=True,
         ) as n:
 
             name = 'root'

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -94,7 +94,7 @@ def test_rpc_errors(arb_addr, to_call, testdir):
                 func_name=funcname,
                 exposed_mods=exposed_mods,
                 func_defined=True if func_defined else False,
-                rpc_module_paths=subactor_exposed_mods,
+                enable_modules=subactor_exposed_mods,
             )
 
     def run():

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -74,11 +74,15 @@ def test_rpc_errors(arb_addr, to_call, testdir):
         remote_err = inside_err
 
     async def main():
-        actor = tractor.current_actor()
-        assert actor.is_arbiter
 
         # spawn a subactor which calls us back
-        async with tractor.open_nursery() as n:
+        async with tractor.open_nursery(
+            arbiter_addr=arb_addr,
+            enable_modules=exposed_mods.copy(),
+        ) as n:
+
+            actor = tractor.current_actor()
+            assert actor.is_arbiter
             await n.run_in_actor(
                 sleep_back_actor,
                 actor_name=subactor_requests_to,
@@ -94,11 +98,7 @@ def test_rpc_errors(arb_addr, to_call, testdir):
             )
 
     def run():
-        tractor.run(
-            main,
-            arbiter_addr=arb_addr,
-            rpc_module_paths=exposed_mods.copy(),
-        )
+        trio.run(main)
 
     # handle both parameterized cases
     if exposed_mods and func_defined:

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -132,7 +132,9 @@ class ActorNursery:
 
         portal = await self.start_actor(
             name,
-            enable_modules=[mod_path] + (enable_modules or rpc_module_paths or []),
+            enable_modules=[mod_path] + (
+                enable_modules or rpc_module_paths or []
+            ),
             bind_addr=bind_addr,
             loglevel=loglevel,
             # use the run_in_actor nursery
@@ -367,7 +369,6 @@ async def open_nursery(
                 async with _open_and_supervise_one_cancels_all_nursery(
                     actor
                 ) as anursery:
-
                     yield anursery
 
         else:  # sub-nursery case

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -113,6 +113,7 @@ class ActorNursery:
         name: Optional[str] = None,
         bind_addr: Tuple[str, int] = _default_bind_addr,
         rpc_module_paths: Optional[List[str]] = None,
+        enable_modules: List[str] = None,
         loglevel: str = None,  # set log level per subactor
         **kwargs,  # explicit args to ``fn``
     ) -> Portal:
@@ -131,7 +132,7 @@ class ActorNursery:
 
         portal = await self.start_actor(
             name,
-            rpc_module_paths=[mod_path] + (rpc_module_paths or []),
+            enable_modules=[mod_path] + (enable_modules or rpc_module_paths or []),
             bind_addr=bind_addr,
             loglevel=loglevel,
             # use the run_in_actor nursery


### PR DESCRIPTION
This should start resolving the following:
- [ ] #183
- [x] #182
- [x] repair the bug found in #163 
- [x]  #177
  - The removal of `tractor.run()` is going to require a big edit of the test set and examples.
  - [x]  [`tractor_test`](https://github.com/goodboy/tractor/blob/master/tractor/testing/_tractor_test.py#L57) is going to need to be redone
  - [x]  the boatload of [tests still using it](https://github.com/search?q=tractor.run+repo%3Agoodboy%2Ftractor+path%3Atests&type=Code)
  - [x] all the [docs examples](https://github.com/search?q=tractor.run+repo%3Agoodboy%2Ftractor+path%3Aexamples&type=Code&ref=advsearch&l=&l=)
- [x]  #168