### PR TITLE
Drop sync func invocation support.

### DIFF
--- a/examples/actor_spawning_and_causality.py
+++ b/examples/actor_spawning_and_causality.py
@@ -1,7 +1,7 @@
 import tractor
 
 
-def cellar_door():
+async def cellar_door():
     assert not tractor.is_root_process()
     return "Dang that's beautiful"
 

--- a/examples/actor_spawning_and_causality_with_daemon.py
+++ b/examples/actor_spawning_and_causality_with_daemon.py
@@ -1,7 +1,7 @@
 import tractor
 
 
-def movie_theatre_question():
+async def movie_theatre_question():
     """A question asked in a dark theatre, in a tangent
     (errr, I mean different) process.
     """

--- a/examples/parallelism/concurrent_actors_primes.py
+++ b/examples/parallelism/concurrent_actors_primes.py
@@ -29,7 +29,7 @@ PRIMES = [
 ]
 
 
-def is_prime(n):
+async def is_prime(n):
     if n < 2:
         return False
     if n == 2:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('docs/README.rst', encoding='utf-8') as f:
 
 setup(
     name="tractor",
-    version='0.1.0a0',  # first ever alpha
+    version='0.1.0a1',  # first ever alpha
     description='structured concurrrent "actors"',
     long_description=readme,
     license='GPLv3',

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -120,7 +120,7 @@ def test_multierror_fast_nursery(arb_addr, start_method, num_subactors, delay):
         assert exc.type == AssertionError
 
 
-def do_nothing():
+async def do_nothing():
     pass
 
 

--- a/tests/test_spawning.py
+++ b/tests/test_spawning.py
@@ -51,7 +51,7 @@ def test_local_arbiter_subactor_global_state(arb_addr):
     assert result == 10
 
 
-def movie_theatre_question():
+async def movie_theatre_question():
     """A question asked in a dark theatre, in a tangent
     (errr, I mean different) process.
     """
@@ -80,7 +80,7 @@ async def test_movie_theatre_convo(start_method):
         await portal.cancel_actor()
 
 
-def cellar_door():
+async def cellar_door():
     return "Dang that's beautiful"
 
 

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -178,6 +178,10 @@ def _get_mod_abspath(module):
     return os.path.abspath(module.__file__)
 
 
+# process-global stack closed at end on actor runtime teardown
+_lifetime_stack: ExitStack = ExitStack()
+
+
 class Actor:
     """The fundamental concurrency primitive.
 
@@ -192,7 +196,6 @@ class Actor:
     _root_n: Optional[trio.Nursery] = None
     _service_n: Optional[trio.Nursery] = None
     _server_n: Optional[trio.Nursery] = None
-    _lifetime_stack: ExitStack = ExitStack()
 
     # Information about `__main__` from parent
     _parent_main_data: Dict[str, str]
@@ -545,8 +548,9 @@ class Actor:
                     # deadlock and other weird behaviour)
                     if func != self.cancel:
                         if isinstance(cs, Exception):
-                            log.warning(f"Task for RPC func {func} failed with"
-                                     f"{cs}")
+                            log.warning(
+                                f"Task for RPC func {func} failed with"
+                                f"{cs}")
                         else:
                             # mark that we have ongoing rpc tasks
                             self._ongoing_rpc_tasks = trio.Event()
@@ -784,7 +788,7 @@ class Actor:
             # tear down all lifetime contexts if not in guest mode
             # XXX: should this just be in the entrypoint?
             log.warning("Closing all actor lifetime contexts")
-            self._lifetime_stack.close()
+            _lifetime_stack.close()
 
             # Unregister actor from the arbiter
             if registered_with_arbiter and (
@@ -857,6 +861,14 @@ class Actor:
         finally:
             # signal the server is down since nursery above terminated
             self._server_down.set()
+
+    def cancel_soon(self) -> None:
+        """Cancel this actor asap; can be called from a sync context.
+
+        Schedules `.cancel()` to be run immediately just like when
+        cancelled by the parent.
+        """
+        self._service_n.start_soon(self.cancel)
 
     async def cancel(self) -> bool:
         """Cancel this actor.

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -868,6 +868,7 @@ class Actor:
         Schedules `.cancel()` to be run immediately just like when
         cancelled by the parent.
         """
+        assert self._service_n
         self._service_n.start_soon(self.cancel)
 
     async def cancel(self) -> bool:

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -182,7 +182,7 @@ class Portal:
         first_msg = await recv_chan.receive()
         functype = first_msg.get('functype')
 
-        if functype == 'function' or functype == 'asyncfunction':
+        if functype == 'asyncfunc':
             resp_type = 'return'
         elif functype == 'asyncgen':
             resp_type = 'yield'


### PR DESCRIPTION
Resolves #77.

Realized we had a bunch of arbiter methods that were sync and of course now the concurrent primes example function needs to be async. Looks a little unwelcoming imo but then again if peeps are here and don't want to make everything `async` maybe it's the wrong spot 😂 

Also, as mentioned in the readme, [`trio-parallel`](https://github.com/richardsheridan/trio-parallel) for anyone who wants the sync func support.