### PR TITLE
Try msgspec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,20 @@ setup(
         'tractor.testing',
     ],
     install_requires=[
+
+        # trio related
         'trio>0.8',
-        'msgpack',
         'async_generator',
+        'tricycle',
+        'trio_typing',
+
         'colorlog',
         'wrapt',
-        'trio_typing',
         'pdbpp',
+
+        # serialization
+        'msgpack',
+        'msgspec',
     ],
     tests_require=['pytest'],
     python_requires=">=3.7",

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -279,7 +279,7 @@ class Actor:
         # TODO: consider making this a dynamically defined
         # @dataclass once we get py3.7
         self.loglevel = loglevel
-        self._arb_addr = tuple(arbiter_addr) if arbiter_addr is not None else None
+        self._arb_addr = tuple(arbiter_addr) if arbiter_addr is not None else (None, None)
 
         # marked by the process spawning backend at startup
         # will be None for the parent most process started manually
@@ -691,7 +691,15 @@ class Actor:
                 _state._runtime_vars.update(rvs)
 
                 for attr, value in parent_data.items():
-                    setattr(self, attr, value)
+
+                    if attr == '_arb_addr':
+                        # XXX: msgspec doesn't support serializing tuples
+                        # so just cash manually here since it's what our
+                        # internals expect.
+                        self._arb_addr = tuple(value)
+
+                    else:
+                        setattr(self, attr, value)
 
                 # Disable sigint handling in children if NOT running in
                 # debug mode; we shouldn't need it thanks to our

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -279,7 +279,7 @@ class Actor:
         # TODO: consider making this a dynamically defined
         # @dataclass once we get py3.7
         self.loglevel = loglevel
-        self._arb_addr = arbiter_addr
+        self._arb_addr = tuple(arbiter_addr) if arbiter_addr is not None else None
 
         # marked by the process spawning backend at startup
         # will be None for the parent most process started manually
@@ -529,6 +529,7 @@ class Actor:
                 # ``scope = Nursery.start()``
                 task_status.started(loop_cs)
                 async for msg in chan:
+
                     if msg is None:  # loop terminate sentinel
 
                         log.debug(
@@ -1075,10 +1076,10 @@ class Actor:
         parlance.
         """
         await chan.send(self.uid)
-        uid: Tuple[str, str] = await chan.recv()
+        uid: Tuple[str, str] = tuple(await chan.recv())
 
-        if not isinstance(uid, tuple):
-            raise ValueError(f"{uid} is not a valid uid?!")
+        # if not isinstance(uid, tuple):
+        #     raise ValueError(f"{uid} is not a valid uid?!")
 
         chan.uid = uid
         log.info(f"Handshake with actor {uid}@{chan.raddr} complete")
@@ -1145,8 +1146,9 @@ class Arbiter(Actor):
     async def register_actor(
         self, uid: Tuple[str, str], sockaddr: Tuple[str, int]
     ) -> None:
+        uid = tuple(uid)
         name, uuid = uid
-        self._registry[uid] = sockaddr
+        self._registry[uid] = tuple(sockaddr)
 
         # pop and signal all waiter events
         events = self._waiters.pop(name, ())
@@ -1156,4 +1158,4 @@ class Arbiter(Actor):
                 event.set()
 
     async def unregister_actor(self, uid: Tuple[str, str]) -> None:
-        self._registry.pop(uid)
+        self._registry.pop(tuple(uid))

--- a/tractor/_exceptions.py
+++ b/tractor/_exceptions.py
@@ -41,6 +41,10 @@ class ContextCancelled(RemoteActorError):
     "Inter-actor task context cancelled itself on the callee side."
 
 
+class TransportClosed(trio.ClosedResourceError):
+    "Underlying channel transport was closed prior to use"
+
+
 class NoResult(RuntimeError):
     "No final result is expected for this actor"
 
@@ -66,12 +70,15 @@ def pack_error(exc: BaseException) -> Dict[str, Any]:
 
 
 def unpack_error(
+
     msg: Dict[str, Any],
     chan=None,
     err_type=RemoteActorError
+
 ) -> Exception:
     """Unpack an 'error' message from the wire
     into a local ``RemoteActorError``.
+
     """
     error = msg['error']
 

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -2,7 +2,6 @@
 Inter-process comms abstractions
 """
 from functools import partial
-import math
 import struct
 import typing
 from typing import Any, Tuple, Optional
@@ -49,9 +48,8 @@ class MsgpackTCPStream:
         assert isinstance(rsockname, tuple)
         self._raddr = rsockname[:2]
 
-        # start and seed first entry to read loop
+        # start first entry to read loop
         self._agen = self._iter_packets()
-        # self._agen.asend(None) is None
 
         self._send_lock = trio.StrictFIFOLock()
 
@@ -225,7 +223,6 @@ class Channel:
 
         stream = await trio.open_tcp_stream(
             *destaddr,
-            happy_eyeballs_delay=math.inf,
             **kwargs
         )
         self.msgstream = self.stream_serializer_type(stream)


### PR DESCRIPTION
First draft trying out `msgspec` over `msgpack-python`.

~We currently can't easily decode streams since there's no api support~, see:
https://github.com/jcrist/msgspec/issues/27, see the updates; we just need to implement our own framing with a bytes len prefix 🥳 

The bulk of speed improvements are supposed to come from decoding + validation so we're not really seeing benefits from either of those yet 😂 

TODO:
- [ ] add nested structs for our ipc protocol for #36 
- [ ] offer a way to specify which serialization lib is used at runtime startup (likely much like the `start_method` kwarg to `open_root_actor()`), maybe `serialization_method`?
- [ ] fix up [the remaining failing tests which are shipping `defaultdict`s](https://github.com/goodboy/tractor/pull/212/checks?check_run_id=2806536791#step:5:1232) for some reason
- [ ] appease `mypy` stuff
- [ ] potentially offer `msgpack-numpy` as the optional dep if we end up liking the performance here?
- [ ] oh right, pin to python 3.8+ (since `msgspec` requires it) and we might as well sine we're onto a new alpha release anyway
- [ ] document `msgspec` use in the readme