### PR TITLE
Add .alpha1 news flash

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,0 +1,100 @@
+=========
+Changelog
+=========
+
+tractor 0.1.0a1 (2021-08-01)
+============================
+
+Features
+--------
+- Updated our uni-directional streaming API (`#206
+  <https://github.com/goodboy/tractor/pull/206>`) to require a context
+  manager style ``async Portal.stream_from(target) as stream:`` which
+  explicitly determines when to stop a stream in the calling (aka portal
+  opening) actor much like ``async_generator.aclosing()`` enforcement.
+
+- Improved the ``multiprocessing`` backend sub-actor reaping (`#208
+  <https://github.com/goodboy/tractor/pull/208>`) during actor nursery
+  exit, particularly during cancellation scenarios that previously might
+  result in hard to debug hangs.
+
+- Added initial bi-directional streaming support in `#219
+  <https://github.com/goodboy/tractor/pull/219>` with follow up debugger
+  improvements via `#220 <https://github.com/goodboy/tractor/pull/220>`
+  using the new ``tractor.Context`` cross-actor task syncing system.
+  The debugger upgrades add an edge triggered last-in-tty-lock semaphore
+  which allows the root process for a tree to avoid clobbering children
+  who have queued to acquire the ``pdb`` repl by waiting to cancel
+  sub-actors until the lock is known to be released **and** has no
+  pending waiters.
+
+
+Experiments and WIPs
+--------------------
+- Initial optional ``msgspec`` serialization support in `#214
+  <https://github.com/goodboy/tractor/pull/214>` which should hopefully
+  land by next release.
+
+- Improved "infect ``asyncio``" cross-loop task cancellation and error
+  propagation by vastly simplifying the approach.  We may end up just
+  going with a use of ``anyio`` in the medium term to avoid re-doing
+  work done by that group cross-event-loop portals.  See the
+  ``infect_asyncio`` for details.
+
+
+Improved Documentation
+----------------------
+- `Updated our readme <https://github.com/goodboy/tractor/pull/211>` to
+  include more (and better) `examples
+  <https://github.com/goodboy/tractor#run-a-func-in-a-process>` (with
+  matching multi-terminal process monitoring shell commands) as well as
+  added many more examples to the `repo set
+  <https://github.com/goodboy/tractor/tree/master/examples>`.
+
+- Added a readme `"actors under the hood" section
+  <https://github.com/goodboy/tractor#under-the-hood>` in an effort to
+  guard against suggestions for changing the API away from ``trio``'s
+  *tasks-as-functions* style.
+
+- Moved to using the `sphinx book theme
+  <https://sphinx-book-theme.readthedocs.io/en/latest/index.html>`
+  though it needs some heavy tweaking and doesn't seem to show our logo
+  on rtd :(
+
+
+Trivial/Internal Changes
+------------------------
+- Added a new ``TransportClosed`` internal exception/signal (`#215
+  <https://github.com/goodboy/tractor/pull/215>` for catching TCP
+  channel gentle closes instead of silently falling through the message
+  handler loop via an async generator ``return```.
+
+
+Deprecations and Removals
+-------------------------
+- Dropped support for invoking sync functions (`#205
+  <https://github.com/goodboy/tractor/pull/205>`) in other
+  actors/processes since you can always wrap a sync function from an
+  async one.  Users can instead consider using ``trio-parallel`` which
+  is a project specifically geared for purely synchronous calls in
+  sub-processes.
+
+- Deprecated our ``tractor.run()`` entrypoint `#197
+  <https://github.com/goodboy/tractor/pull/197>`; the runtime is now
+  either started implicitly in first actor nursery use or via an
+  explicit call to ``tractor.open_root_actor()``. Full removal of
+  ``tractor.run()`` will come by beta release.
+
+
+tractor 0.1.0a0 (2021-02-28)
+============================
+
+..
+    TODO: fill out more of the details of the initial feature set in some TLDR form
+
+Summary
+-------
+- ``trio`` based process spawner (using ``subprocess``)
+- initial multi-process debugging with ``pdb++``
+- windows support using both ``trio`` and ``multiprocessing`` spawners
+- "portal" api for cross-process, structured concurrent, (streaming) IPC


### PR DESCRIPTION
News fragments for an `.alpha1` release that I'd like to get out tomorrow 😎 

ping @Fuyukai.

For the *trio feed* what markup would you prefer for the summary of this?

In markdown it'll likely go something like:

---

For those who haven't heard of us, ``tractor`` is a multi-processing-runtime library which applies structured concurrency from the ground up on process managment and IPC. We had our first alpha release this past Feb. and now our second this Aug. 1st 🥳.

The quick and dirty summary for this release is:
- Updated our unidirectional streaming APIs to be more `async_generator.aclosing()`-like
- Vastly improved our actor reaping during cancellation and error propagation for the `multiprocessing` spawner backend
- Added a next-gen, fully bi-directional streaming API with complete, transitive SC semantics for IPC 🏄🏼‍♀️ 
- Hardened our multi-process debugger support (ala `pdb++`) to prevent root process clobbers of children who have acquired the repl tty lock; this is thanks to our new ``tractor.Context`` cross-actor-task syncing protocol.
- Started some tinkering with `msgspec` for an optional alternative to `msgpack-python`.
- Improved our infected-`asyncio`-in-guest-mode cross-loop streaming semantics by simplifying to memory channel only style data passing between frameworks.
- Added a ton of new examples to both the readme and repository  script set.
- Removed both `tractor.run()` and support for invoking sync functions; instead we recommend users try `trio-parallel`!

For more details see our [new release](https://github.com/goodboy/tractor/blob/master/NEWS.rst).

NB: last link is broken until this lands.