### PR TITLE
Drop stream shielding; it was from a legacy api design

### DIFF
--- a/newsfragments/230.removal.rst
+++ b/newsfragments/230.removal.rst
@@ -1,0 +1,9 @@
+Drop stream "shielding" support which was originally added to sidestep
+a cancelled call to ``.receive()``
+
+In the original api design a stream instance was returned directly from
+a call to ``Portal.run()`` and thus there was no "exit phase" to handle
+cancellations and errors which would trigger implicit closure. Now that
+we have said enter/exit semantics with ``Portal.open_stream_from()`` and
+``Context.open_stream()`` we can drop this implicit (and arguably
+confusing) behavior.

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -313,12 +313,12 @@ async def test_respawn_consumer_task(
                     task_status.started(cs)
 
                     # shield stream's underlying channel from cancellation
-                    with stream.shield():
+                    # with stream.shield():
 
-                        async for v in stream:
-                            print(f'from stream: {v}')
-                            expect.remove(v)
-                            received.append(v)
+                    async for v in stream:
+                        print(f'from stream: {v}')
+                        expect.remove(v)
+                        received.append(v)
 
                     print('exited consume')
 


### PR DESCRIPTION
Before we had `async with Portal.open_stream_from()` which has explicit enter/exit semantics, we had a implicit *portal-returns-stream-reference* thing which required that if a `stream.receive()` was cancelled, we relayed that via a stream closure to the other side.

Since we have the new API now we don't need this shielding (aka we won't `.aclose()` the stream on cancellation) any more.

This PR removes all that and the CI should prove that all things are well. 

Once CI is clean I'll just remove the first patch draft which comments all the unneeded code.