### PR TITLE
Root tty hangs

### DIFF
--- a/newsfragments/234.bugfix
+++ b/newsfragments/234.bugfix
@@ -1,0 +1,6 @@
+Handle broken channel/stream faults where the root's tty lock is left acquired by some
+child actor who went MIA and the root ends up hanging indefinitely.
+
+There's two parts here:
+- Don't shield wait on the lock
+- Always do our best to release the lock on the expected worst case connection faults

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -23,6 +23,7 @@ from ._exceptions import (
 from ._debug import breakpoint, post_mortem
 from . import msg
 from ._root import run, run_daemon, open_root_actor
+from ._portal import Portal
 
 
 __all__ = [
@@ -40,6 +41,7 @@ __all__ = [
     'msg',
     'open_nursery',
     'open_root_actor',
+    'Portal',
     'post_mortem',
     'run',
     'run_daemon',

--- a/tractor/_debug.py
+++ b/tractor/_debug.py
@@ -418,12 +418,13 @@ async def _breakpoint(
     debug_func(actor)
 
 
-def _mk_pdb():
+def _mk_pdb() -> PdbwTeardown:
+
     # XXX: setting these flags on the pdb instance are absolutely
-    # critical to having ctrl-c work in the ``trio`` standard way!
-    # The stdlib's pdb supports entering the current sync frame
-    # on a SIGINT, with ``trio`` we pretty much never want this
-    # and we did we can handle it in the ``tractor`` task runtime.
+    # critical to having ctrl-c work in the ``trio`` standard way!  The
+    # stdlib's pdb supports entering the current sync frame on a SIGINT,
+    # with ``trio`` we pretty much never want this and if we did we can
+    # handle it in the ``tractor`` task runtime.
 
     pdb = PdbwTeardown()
     pdb.allow_kbdint = True

--- a/tractor/_debug.py
+++ b/tractor/_debug.py
@@ -196,6 +196,22 @@ async def _acquire_debug_lock(
         log.debug(f"TTY lock released, remote task: {task_name}:{uid}")
 
 
+def handler(signum, frame, *args):
+    """Specialized debugger compatible SIGINT handler.
+
+    In childred we always ignore to avoid deadlocks since cancellation
+    should always be managed by the parent supervising actor. The root
+    is always cancelled on ctrl-c.
+    """
+    if is_root_process():
+        tractor.current_actor().cancel_soon()
+    else:
+        print(
+            "tractor ignores SIGINT while in debug mode\n"
+            "If you have a special need for it please open an issue.\n"
+        )
+
+
 @tractor.context
 async def _hijack_stdin_for_child(
 

--- a/tractor/_entry.py
+++ b/tractor/_entry.py
@@ -62,7 +62,7 @@ def _trio_main(
     """
     # Disable sigint handling in children;
     # we don't need it thanks to our cancellation machinery.
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    # signal.signal(signal.SIGINT, signal.SIG_IGN)
 
     log.info(f"Started new trio process for {actor.uid}")
 

--- a/tractor/_trionics.py
+++ b/tractor/_trionics.py
@@ -298,8 +298,8 @@ async def _open_and_supervise_one_cancels_all_nursery(
                                 f'child {_debug._global_actor_in_debug}\n'
                                 'Waiting on tty lock to release..')
 
-                            with trio.CancelScope(shield=True):
-                                await debug_complete.wait()
+                            # with trio.CancelScope(shield=True):
+                            await debug_complete.wait()
 
                     # if the caller's scope errored then we activate our
                     # one-cancels-all supervisor strategy (don't


### PR DESCRIPTION
Debugger improvements to avoid even further tty clobbering edge cases and potential root actor hangs when the debug lock is acquired but the child completes or intends to release it but the root never is notified.