### PR TITLE
Fix kbi in ctx block

### DIFF
--- a/newsfragments/239.bug.rst
+++ b/newsfragments/239.bug.rst
@@ -1,0 +1,6 @@
+Fix keyboard interrupt handling in ``Portal.open_context()`` blocks.
+
+Previously this not triggering cancellation of the remote task context
+and could result in hangs if a stream was also opened. This fix is to
+accept `BaseException` since it is likely any other top level exception
+other then kbi (even though not expected) should also get this result.

--- a/tests/test_2way.py
+++ b/tests/test_2way.py
@@ -126,6 +126,10 @@ def test_simple_context(
             trio.run(main)
         except error_parent:
             pass
+        except trio.MultiError as me:
+            # XXX: on windows it seems we may have to expect the group error
+            from tractor._exceptions import is_multi_cancelled
+            assert is_multi_cancelled(me)
     else:
         trio.run(main)
 

--- a/tests/test_2way.py
+++ b/tests/test_2way.py
@@ -2,6 +2,8 @@
 Bidirectional streaming and context API.
 
 """
+import platform
+
 import pytest
 import trio
 import tractor
@@ -69,9 +71,11 @@ def test_simple_context(
     pointlessly_open_stream,
 ):
 
+    timeout = 1.5 if not platform.system() == 'Windows' else 3
+
     async def main():
 
-        with trio.fail_after(1.5):
+        with trio.fail_after(timeout):
             async with tractor.open_nursery() as nursery:
 
                 portal = await nursery.start_actor(

--- a/tests/test_task_broadcasting.py
+++ b/tests/test_task_broadcasting.py
@@ -1,5 +1,6 @@
 """
 Broadcast channels for fan-out to local tasks.
+
 """
 from contextlib import asynccontextmanager
 from functools import partial
@@ -332,6 +333,9 @@ def test_ensure_slow_consumers_lag_out(
                                 await trio.sleep(delay)
 
                             if task.name == 'sub_1':
+                                # trigger checkpoint to clean out other subs
+                                await trio.sleep(0)
+
                                 # the non-lagger got
                                 # a ``trio.EndOfChannel``
                                 # because the ``tx`` below was closed

--- a/tractor/log.py
+++ b/tractor/log.py
@@ -52,6 +52,8 @@ BOLD_PALETTE = {
 }
 
 
+# TODO: this isn't showing the correct '{filename}'
+# as it did before..
 class StackLevelAdapter(logging.LoggerAdapter):
 
     def transport(


### PR DESCRIPTION
Fix for an issue discovered in the development of [`wrath`](https://github.com/adder46/wrath) - thanks to @adder46!

It turns out we need to catch KBI's in `Portal.open_context()` blocks in order to get proper cancellation *if* the block is run inside the top level task (maybe always).  The fix for this is simple, we just need to either explicitly handle the kbi in the block's `__aenter__()` implementation or just handle `BaseException` (which is the likely solution).

Tests are up first to show CI failures, patch will come shortly after.