### PR TITLE
Fix type annotations

### DIFF
--- a/tractor/_clustering.py
+++ b/tractor/_clustering.py
@@ -20,8 +20,8 @@ async def open_actor_cluster(
     start_method: Optional[str] = None,
     hard_kill: bool = False,
 ) -> AsyncGenerator[
-    list[str],
-    dict[str, tractor.Portal]
+    dict[str, tractor.Portal],
+    None,
 ]:
 
     portals: dict[str, tractor.Portal] = {}


### PR DESCRIPTION
The issue was that the yield type was `list[str]` when in fact it should have been `dict[str, tractor.Portal]`. Also, the send type was `dict[str, tractor.Portal]` and it should have been `None`.

(references #241)
