### PR TITLE
Add `maybe_open_context()` an actor wide task-resource cache

### DIFF
--- a/newsfragments/257.feature.rst
+++ b/newsfragments/257.feature.rst
@@ -1,0 +1,9 @@
+Add ``trionics.maybe_open_context()`` an actor-scoped async multi-task
+context manager resource caching API.
+
+Adds an SC-safe cacheing async context manager api that only enters on
+the *first* task entry and only exits on the *last* task exit while in
+between delivering the same cached value per input key. Keys can be
+either an explicit ``key`` named arg provided by the user or a
+hashable ``kwargs`` dict (will be converted to a ``list[tuple]``) which
+is passed to the underlying manager function as input.

--- a/tests/test_resource_cache.py
+++ b/tests/test_resource_cache.py
@@ -3,6 +3,7 @@ Async context manager cache api testing: ``trionics.maybe_open_context():``
 
 '''
 from contextlib import asynccontextmanager as acm
+import platform
 from typing import Awaitable
 
 import trio
@@ -65,6 +66,8 @@ def test_open_local_sub_to_stream():
     N local tasks using ``trionics.maybe_open_context():``.
 
     '''
+    timeout = 3 if platform.system() != "Windows" else 10
+
     async def main():
 
         full = list(range(1000))
@@ -92,7 +95,7 @@ def test_open_local_sub_to_stream():
 
         # TODO: turns out this isn't multi-task entrant XD
         # We probably need an indepotent entry semantic?
-        with trio.fail_after(3):
+        with trio.fail_after(timeout):
             async with tractor.open_root_actor():
                 async with (
                     trio.open_nursery() as nurse,

--- a/tests/test_resource_cache.py
+++ b/tests/test_resource_cache.py
@@ -1,0 +1,104 @@
+'''
+Async context manager cache api testing: ``trionics.maybe_open_context():``
+
+'''
+from contextlib import asynccontextmanager as acm
+from typing import Awaitable
+
+import trio
+import tractor
+
+
+@tractor.context
+async def streamer(
+    ctx: tractor.Context,
+    seq: list[int] = list(range(1000)),
+) -> None:
+
+    await ctx.started()
+    async with ctx.open_stream() as stream:
+        for val in seq:
+            await stream.send(val)
+            await trio.sleep(0.001)
+
+
+@acm
+async def open_stream() -> Awaitable[tractor.MsgStream]:
+
+    async with tractor.open_nursery() as tn:
+        portal = await tn.start_actor('streamer', enable_modules=[__name__])
+        async with (
+            portal.open_context(streamer) as (ctx, first),
+            ctx.open_stream() as stream,
+        ):
+            yield stream
+            breakpoint()
+
+        print('CANCELLING STREAMER')
+        await portal.cancel_actor()
+
+
+@acm
+async def maybe_open_stream(taskname: str):
+    async with tractor.trionics.maybe_open_context(
+        # NOTE: all secondary tasks should cache hit on the same key
+        key='stream',
+        mngr=open_stream(),
+    ) as (cache_hit, stream):
+
+        if cache_hit:
+            print(f'{taskname} loaded from cache')
+
+            # add a new broadcast subscription for the quote stream
+            # if this feed is already allocated by the first
+            # task that entereed
+            async with stream.subscribe() as bstream:
+                yield bstream
+        else:
+            # yield the actual stream
+            yield stream
+
+
+def test_open_local_sub_to_stream():
+    '''
+    Verify a single inter-actor stream can can be fanned-out shared to
+    N local tasks using ``trionics.maybe_open_context():``.
+
+    '''
+    async def main():
+
+        full = list(range(1000))
+
+        async def get_sub_and_pull(taskname: str):
+            async with (
+                maybe_open_stream(taskname) as stream,
+            ):
+                if '0' in taskname:
+                    assert isinstance(stream, tractor.MsgStream)
+                else:
+                    assert isinstance(
+                        stream,
+                        tractor.trionics.BroadcastReceiver
+                    )
+
+                first = await stream.receive()
+                print(f'{taskname} started with value {first}')
+                seq = []
+                async for msg in stream:
+                    seq.append(msg)
+                    print(f'{taskname} received {msg}')
+
+                assert set(seq).issubset(set(full))
+                print(f'{taskname} finished')
+
+        # TODO: turns out this isn't multi-task entrant XD
+        # We probably need an indepotent entry semantic?
+        async with tractor.open_root_actor():
+            async with (
+                trio.open_nursery() as nurse,
+            ):
+                for i in range(10):
+                    nurse.start_soon(get_sub_and_pull, f'task_{i}')
+                    await trio.sleep(0.001)
+
+    trio.run(main)

--- a/tractor/_root.py
+++ b/tractor/_root.py
@@ -215,6 +215,14 @@ async def open_root_actor(
                 raise
 
             finally:
+                # NOTE: not sure if we'll ever need this but it's
+                # possibly better for even more determinism?
+                # logger.cancel(f'Waiting on {len(nurseries)} nurseries in root..')
+                # nurseries = actor._actoruid2nursery.values()
+                # async with trio.open_nursery() as tempn:
+                #     for an in nurseries:
+                #         tempn.start_soon(an.exited.wait)
+
                 logger.cancel("Shutting down root actor")
                 await actor.cancel()
     finally:

--- a/tractor/trionics/__init__.py
+++ b/tractor/trionics/__init__.py
@@ -18,8 +18,15 @@
 Sugary patterns for trio + tractor designs.
 
 '''
-from ._mngrs import gather_contexts
-from ._broadcast import broadcast_receiver, BroadcastReceiver, Lagged
+from ._mngrs import (
+    gather_contexts,
+    maybe_open_context,
+)
+from ._broadcast import (
+    broadcast_receiver,
+    BroadcastReceiver,
+    Lagged,
+)
 
 
 __all__ = [
@@ -27,4 +34,5 @@ __all__ = [
     'broadcast_receiver',
     'BroadcastReceiver',
     'Lagged',
+    'maybe_open_context',
 ]

--- a/tractor/trionics/_broadcast.py
+++ b/tractor/trionics/_broadcast.py
@@ -331,10 +331,16 @@ class BroadcastReceiver(ReceiveChannel):
         if self._closed:
             return
 
+        # if there are sleeping consumers wake
+        # them on closure.
+        rr = self._state.recv_ready
+        if rr:
+            _, event = rr
+            event.set()
+
         # XXX: leaving it like this consumers can still get values
         # up to the last received that still reside in the queue.
         self._state.subs.pop(self.key)
-
         self._closed = True
 
 

--- a/tractor/trionics/_mngrs.py
+++ b/tractor/trionics/_mngrs.py
@@ -170,6 +170,7 @@ async def maybe_open_context(
     await _Cache.lock.acquire()
 
     ctx_key = (id(acm_func), key or tuple(kwargs.items()))
+    print(ctx_key)
     value = None
 
     try:
@@ -214,6 +215,10 @@ async def maybe_open_context(
             if _Cache.users <= 0:
                 log.info(f'De-allocating resource for {ctx_key}')
 
-                # terminate mngr nursery
-                _, no_more_users = _Cache.resources[ctx_key]
-                no_more_users.set()
+                # XXX: if we're cancelled we the entry may have never
+                # been entered since the nursery task was killed.
+                # _, no_more_users = _Cache.resources[ctx_key]
+                entry = _Cache.resources.get(ctx_key)
+                if entry:
+                    _, no_more_users = entry
+                    no_more_users.set()

--- a/tractor/trionics/_mngrs.py
+++ b/tractor/trionics/_mngrs.py
@@ -123,7 +123,7 @@ class _Cache:
     users: int = 0
     values: dict[Any,  Any] = {}
     resources: dict[
-        int,
+        Hashable,
         tuple[trio.Nursery, trio.Event]
     ] = {}
     no_more_users: Optional[trio.Event] = None
@@ -155,7 +155,7 @@ async def maybe_open_context(
 
     # XXX: used as cache key after conversion to tuple
     # and all embedded values must also be hashable
-    kwargs: Optional[dict] = {},
+    kwargs: dict = {},
     key: Hashable = None,
 
 ) -> AsyncIterator[tuple[bool, T]]:


### PR DESCRIPTION
Like it sounds: a context manager that only opens a new actor-global (aka mem local) resource if one isn't already cached.

This is particularly handy for resources that can be shared by multiple tasks in and actor where the user desires that the lifetime of the resource is maintained until the final *user task* completes.

Still needs tests obviously.

UPDATE:
This ended up turning into a foray into fixing `MsgStream` closure/termination semantics after trying to get the original resource caching test working.

Todo tests:
- [x] cached inter-actor stream demonstration
- [x] simpler audit of just ensuring that multiple local `trio` tasks get the same cached value
- [x] error/cancel tests? 