### PR TITLE
Fix `Portal.run_in_actor()` returns `None` result

### DIFF
--- a/newsfragments/264.bug.rst
+++ b/newsfragments/264.bug.rst
@@ -1,0 +1,7 @@
+Fix ``Portal.run_in_actor()`` returns ``None`` result.
+
+``None`` was being used as the cached result flag and obviously breaks
+on a ``None`` returned from the remote target task. This would cause an
+infinite hang if user code ever called ``Portal.result()`` *before* the
+nursery exit. The simple fix is to use the ``Channel.uid`` as the
+initial "no-result-received-yet" flag.

--- a/newsfragments/264.bug.rst
+++ b/newsfragments/264.bug.rst
@@ -3,5 +3,6 @@ Fix ``Portal.run_in_actor()`` returns ``None`` result.
 ``None`` was being used as the cached result flag and obviously breaks
 on a ``None`` returned from the remote target task. This would cause an
 infinite hang if user code ever called ``Portal.result()`` *before* the
-nursery exit. The simple fix is to use the ``Channel.uid`` as the
-initial "no-result-received-yet" flag.
+nursery exit. The simple fix is to use the *return message* as the
+initial "no-result-received-yet" flag value and, once received, the
+return value is read from the message to avoid the cache logic error.

--- a/tests/test_spawning.py
+++ b/tests/test_spawning.py
@@ -110,7 +110,7 @@ async def test_most_beautiful_word(
     The main ``tractor`` routine.
 
     '''
-    with trio.fail_after(0.5):
+    with trio.fail_after(1):
         async with tractor.open_nursery() as n:
 
             portal = await n.run_in_actor(

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -21,7 +21,7 @@ from .log import get_logger
 from ._exceptions import (
     unpack_error,
     NoResult,
-    RemoteActorError,
+    # RemoteActorError,
     ContextCancelled,
 )
 from ._streaming import Context, ReceiveMsgStream
@@ -54,8 +54,23 @@ def func_deats(func: Callable) -> Tuple[str, str]:
     )
 
 
+def _unwrap_msg(
+
+    msg: dict[str, Any],
+    channel: Channel
+
+) -> Any:
+    try:
+        return msg['return']
+    except KeyError:
+        # internal error should never get here
+        assert msg.get('cid'), "Received internal error at portal?"
+        raise unpack_error(msg, channel)
+
+
 class Portal:
-    """A 'portal' to a(n) (remote) ``Actor``.
+    '''
+    A 'portal' to a(n) (remote) ``Actor``.
 
     A portal is "opened" (and eventually closed) by one side of an
     inter-actor communication context. The side which opens the portal
@@ -71,7 +86,7 @@ class Portal:
     function calling semantics are supported transparently; hence it is
     like having a "portal" between the seperate actor memory spaces.
 
-    """
+    '''
     def __init__(self, channel: Channel) -> None:
         self.channel = channel
         # when this is set to a tuple returned from ``_submit()`` then
@@ -130,16 +145,11 @@ class Portal:
         resptype: str,
         first_msg: dict
 
-    ) -> tuple[Any, dict[str, Any]]:
-        assert resptype == 'asyncfunc'  # single response
+    ) -> dict[str, Any]:
 
+        assert resptype == 'asyncfunc'  # single response
         msg = await recv_chan.receive()
-        try:
-            return msg['return'], msg
-        except KeyError:
-            # internal error should never get here
-            assert msg.get('cid'), "Received internal error at portal?"
-            raise unpack_error(msg, self.channel)
+        return msg
 
     async def result(self) -> Any:
         """Return the result(s) from the remote actor's "main" task.
@@ -162,19 +172,9 @@ class Portal:
         assert self._expect_result
 
         if self._result_msg is None:
-            try:
-                result, self._result_msg = await self._return_once(
-                    *self._expect_result)
-            except RemoteActorError as err:
-                result = err
-        else:
-            result = self._result_msg['return']
+            self._result_msg = await self._return_once(*self._expect_result)
 
-        # re-raise error on every call
-        if isinstance(result, RemoteActorError):
-            raise result
-
-        return result
+        return _unwrap_msg(self._result_msg, self.channel)
 
     async def _cancel_streams(self):
         # terminate all locally running async generator
@@ -249,10 +249,10 @@ class Portal:
             instance methods in the remote runtime. Currently this should only
             be used for `tractor` internals.
         """
-        value, _ = await self._return_once(
+        msg = await self._return_once(
             *(await self._submit(namespace_path, function_name, kwargs))
         )
-        return value
+        return _unwrap_msg(msg, self.channel)
 
     async def run(
         self,
@@ -293,9 +293,12 @@ class Portal:
 
             fn_mod_path, fn_name = func_deats(func)
 
-        return (await self._return_once(
-            *(await self._submit(fn_mod_path, fn_name, kwargs))
-        ))[0]
+        return _unwrap_msg(
+            await self._return_once(
+                *(await self._submit(fn_mod_path, fn_name, kwargs)),
+            ),
+            self.channel,
+        )
 
     @asynccontextmanager
     async def open_stream_from(

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -77,7 +77,7 @@ class Portal:
         # when this is set to a tuple returned from ``_submit()`` then
         # it is expected that ``result()`` will be awaited at some point
         # during the portal's lifetime
-        self._result: Optional[Any] = None
+        self._result: Optional[Any] = channel.uid
         # set when _submit_for_result is called
         self._expect_result: Optional[
             Tuple[str, Any, str, Dict[str, Any]]
@@ -128,6 +128,7 @@ class Portal:
         recv_chan: trio.abc.ReceiveChannel,
         resptype: str,
         first_msg: dict
+
     ) -> Any:
         assert resptype == 'asyncfunc'  # single response
 
@@ -158,7 +159,7 @@ class Portal:
 
         # expecting a "main" result
         assert self._expect_result
-        if self._result is None:
+        if self._result is self.channel.uid:
             try:
                 self._result = await self._return_once(*self._expect_result)
             except RemoteActorError as err:


### PR DESCRIPTION
`None` was being used as the *cached result* flag and obviously breaks on a `None` returned from the remote target task 😂 . This would cause an infinite hang if user code ever called `Portal.result()` *before* the nursery exit..

Simple fix by just using the `Channel.uid` as the initial *no result yet received yet* flag.