### PR TITLE
Acked remote cancels

### DIFF
--- a/newsfragments/267.misc.rst
+++ b/newsfragments/267.misc.rst
@@ -1,0 +1,16 @@
+This (finally) adds fully acknowledged remote cancellation messaging
+support for both explicit ``Portal.cancel_actor()`` calls as well as
+when there is a "runtime-wide" cancellations (eg. during KBI or general
+actor nursery exception handling which causes a full actor
+"crash"/termination).
+
+You can think of this as the most ideal case in 2-generals where the
+actor requesting the cancel of its child is able to always receive back
+the ACK to that request. This leads to a more deterministic shutdown of
+the child where the parent is able to wait for the child to fully
+respond to the request. On a localhost setup, where the parent can
+monitor the state of the child through process or other OS APIs instead
+of solely through IPC messaging, the parent can know whether or not the
+child decided to cancel with more certainty. In the case of separate
+hosts, we still rely on a simple timeout approach until such a time
+where we prefer to get "fancier".

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -128,7 +128,11 @@ def test_multierror_fast_nursery(arb_addr, start_method, num_subactors, delay):
 
     if len(exceptions) == 2:
         # sometimes oddly now there's an embedded BrokenResourceError ?
-        exceptions = exceptions[1].exceptions
+        for exc in exceptions:
+            excs = getattr(exc, 'exceptions', None)
+            if excs:
+                exceptions = excs
+                break
 
     assert len(exceptions) == num_subactors
 

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -2,6 +2,7 @@
 Actor primitives and helpers
 
 """
+from __future__ import annotations
 from collections import defaultdict
 from functools import partial
 from itertools import chain
@@ -56,6 +57,8 @@ async def _invoke(
 ):
     '''
     Invoke local func and deliver result(s) over provided channel.
+
+    This is the core "RPC task" starting machinery.
 
     '''
     __tracebackhide__ = True
@@ -263,14 +266,51 @@ def _get_mod_abspath(module):
 _lifetime_stack: ExitStack = ExitStack()
 
 
-class Actor:
-    """The fundamental concurrency primitive.
+async def try_ship_error_to_parent(
+    actor: Actor,
+    err: Exception,
 
-    An *actor* is the combination of a regular Python process
-    executing a ``trio`` task tree, communicating
-    with other actors through "portals" which provide a native async API
-    around various IPC transport "channels".
-    """
+) -> None:
+    with trio.CancelScope(shield=True):
+        try:
+            # internal error so ship to parent without cid
+            await actor._parent_chan.send(pack_error(err))
+        except (
+            trio.ClosedResourceError,
+            trio.BrokenResourceError,
+        ):
+            log.error(
+                f"Failed to ship error to parent "
+                f"{actor._parent_chan.uid}, channel was closed"
+            )
+
+
+class Actor:
+    '''
+    The fundamental "runtime" concurrency primitive.
+
+    An *actor* is the combination of a regular Python process executing
+    a ``trio`` task tree, communicating with other actors through
+    "memory boundary portals" - which provide a native async API around
+    IPC transport "channels" which themselves encapsulate various
+    (swappable) network protocols.
+
+
+    Each "actor" is ``trio.run()`` scheduled "runtime" composed of many
+    concurrent tasks in a single thread. The "runtime" tasks conduct
+    a slew of low(er) level functions to make it possible for message
+    passing between actors as well as the ability to create new actors
+    (aka new "runtimes" in new processes which are supervised via
+    a nursery construct). Each task which sends messages to a task in
+    a "peer" (not necessarily a parent-child, depth hierarchy)) is able
+    to do so via an "address", which maps IPC connections across memory
+    boundaries, and task request id which allows for per-actor
+    tasks to send and receive messages to specific peer-actor tasks with
+    which there is an ongoing RPC/IPC dialog.
+
+    '''
+    # ugh, we need to get rid of this and replace with a "registry" sys
+    # https://github.com/goodboy/tractor/issues/216
     is_arbiter: bool = False
 
     # nursery placeholders filled in by `_async_main()` after fork
@@ -441,8 +481,8 @@ class Actor:
             # we need this for ``msgspec`` for some reason?
             # for now, it's been put in the stream backend.
             # trio.BrokenResourceError,
-
             # trio.ClosedResourceError,
+
             TransportClosed,
         ):
             # XXX: This may propagate up from ``Channel._aiter_recv()``
@@ -482,7 +522,49 @@ class Actor:
         # process received reponses.
         try:
             await self._process_messages(chan)
+
+        except trio.Cancelled:
+            log.cancel(f"Msg loop was cancelled for {chan}")
+            raise
+
         finally:
+            # This is set in ``Portal.cancel_actor()``. So if
+            # the peer was cancelled we try to wait for them
+            # to tear down their side of the connection before
+            # moving on with closing our own side.
+            local_nursery = self._actoruid2nursery.get(chan.uid)
+            if (
+                local_nursery
+            ):
+                log.cancel(f"Waiting on cancel request to peer {chan.uid}")
+                # XXX: this is a soft wait on the channel (and its
+                # underlying transport protocol) to close from the remote
+                # peer side since we presume that any channel which
+                # is mapped to a sub-actor (i.e. it's managed by
+                # one of our local nurseries)
+                # message is sent to the peer likely by this actor which is
+                # now in a cancelled condition) when the local runtime here
+                # is now cancelled while (presumably) in the middle of msg
+                # loop processing.
+                with trio.move_on_after(0.1) as cs:
+                    cs.shield = True
+                    # Attempt to wait for the far end to close the channel
+                    # and bail after timeout (2-generals on closure).
+                    async for msg in chan.msgstream.drain():
+                        # try to deliver any lingering msgs
+                        # before we destroy the channel.
+                        # This accomplishes deterministic
+                        # ``Portal.cancel_actor()`` cancellation by
+                        # making sure any RPC response to that call is
+                        # delivered the local calling task.
+                        # TODO: factor this into a helper?
+                        log.runtime(f'drained {msg} for {chan.uid}')
+                        cid = msg.get('cid')
+                        if cid:
+                            # deliver response to local caller/waiter
+                            await self._push_result(chan, cid, msg)
+
+                    await local_nursery.exited.wait()
 
             # channel cleanup sequence
 
@@ -593,10 +675,12 @@ class Actor:
         func: str,
         kwargs: dict
     ) -> Tuple[str, trio.abc.ReceiveChannel]:
-        """Send a ``'cmd'`` message to a remote actor and return a
+        '''
+        Send a ``'cmd'`` message to a remote actor and return a
         caller id and a ``trio.Queue`` that can be used to wait for
         responses delivered by the local message processing loop.
-        """
+
+        '''
         cid = str(uuid.uuid4())
         assert chan.uid
         send_chan, recv_chan = self.get_memchans(chan.uid, cid)
@@ -609,11 +693,14 @@ class Actor:
         chan: Channel,
         shield: bool = False,
         task_status: TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
+
     ) -> None:
-        """Process messages for the channel async-RPC style.
+        '''
+        Process messages for the channel async-RPC style.
 
         Receive multiplexed RPC requests and deliver responses over ``chan``.
-        """
+
+        '''
         # TODO: once https://github.com/python-trio/trio/issues/467 gets
         # worked out we'll likely want to use that!
         msg = None
@@ -692,8 +779,9 @@ class Actor:
                                 # msg loop and break out into
                                 # ``_async_main()``
                                 log.cancel(
-                                    f"Actor {self.uid} was remotely cancelled;"
-                                    " waiting on cancellation completion..")
+                                    f"Actor {self.uid} was remotely cancelled "
+                                    f"by {chan.uid}"
+                                )
                                 await _invoke(
                                     self, cid, chan, func, kwargs, is_rpc=False
                                 )
@@ -789,15 +877,10 @@ class Actor:
                 # machinery not from an rpc task) to parent
                 log.exception("Actor errored:")
                 if self._parent_chan:
-                    await self._parent_chan.send(pack_error(err))
+                    await try_ship_error_to_parent(self, err)
 
             # if this is the `MainProcess` we expect the error broadcasting
             # above to trigger an error at consuming portal "checkpoints"
-            raise
-
-        except trio.Cancelled:
-            # debugging only
-            log.runtime(f"Msg loop was cancelled for {chan}")
             raise
 
         finally:
@@ -891,6 +974,7 @@ class Actor:
             # establish primary connection with immediate parent
             self._parent_chan = None
             if parent_addr is not None:
+
                 self._parent_chan, accept_addr_rent = await self._from_parent(
                     parent_addr)
 
@@ -994,14 +1078,7 @@ class Actor:
                 )
 
             if self._parent_chan:
-                with trio.CancelScope(shield=True):
-                    try:
-                        # internal error so ship to parent without cid
-                        await self._parent_chan.send(pack_error(err))
-                    except trio.ClosedResourceError:
-                        log.error(
-                            f"Failed to ship error to parent "
-                            f"{self._parent_chan.uid}, channel was closed")
+                await try_ship_error_to_parent(self, err)
 
             # always!
             log.exception("Actor errored:")

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -215,7 +215,7 @@ class Portal:
 
         '''
         if not self.channel.connected():
-            log.cancel("This portal is already closed can't cancel")
+            log.cancel("This channel is already closed can't cancel")
             return False
 
         log.cancel(
@@ -239,9 +239,12 @@ class Portal:
             # if we get here some weird cancellation case happened
             return False
 
-        except trio.ClosedResourceError:
+        except (
+            trio.ClosedResourceError,
+            trio.BrokenResourceError,
+        ):
             log.cancel(
-                f"{self.channel} for {self.channel.uid} was already closed?")
+                f"{self.channel} for {self.channel.uid} was already closed or broken?")
             return False
 
     async def run_from_ns(

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -218,8 +218,6 @@ class Portal:
             log.cancel("This portal is already closed can't cancel")
             return False
 
-        await self._cancel_streams()
-
         log.cancel(
             f"Sending actor cancel request to {self.channel.uid} on "
             f"{self.channel}")

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -256,7 +256,8 @@ async def new_proc(
                         # don't clobber an ongoing pdb
                         if is_root_process():
                             await maybe_wait_for_debugger()
-                        else:
+
+                        elif proc is not None:
                             async with acquire_debug_lock(uid):
                                 # soft wait on the proc to terminate
                                 with trio.move_on_after(0.5):

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -5,7 +5,11 @@ Machinery for actor process spawning using multiple backends.
 import sys
 import multiprocessing as mp
 import platform
-from typing import Any, Dict, Optional, Union, Callable
+from typing import (
+    Any, Dict, Optional, Union, Callable,
+    TypeVar,
+)
+from collections.abc import Awaitable, Coroutine
 
 import trio
 from trio_typing import TaskStatus
@@ -41,6 +45,7 @@ from ._exceptions import ActorFailure
 
 
 log = get_logger('tractor')
+ProcessType = TypeVar('ProcessType', mp.Process, trio.Process)
 
 # placeholder for an mp start context if so using that backend
 _ctx: Optional[mp.context.BaseContext] = None
@@ -185,10 +190,10 @@ async def do_hard_kill(
 
 async def soft_wait(
 
-    proc: Union[mp.Process, trio.Process],
+    proc: ProcessType,
     wait_func: Callable[
-        Union[mp.Process, trio.Process],
-        None,
+        [ProcessType],
+        Awaitable,
     ],
     portal: Portal,
 

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -97,14 +97,17 @@ def try_set_start_method(name: str) -> Optional[mp.context.BaseContext]:
 
 
 async def exhaust_portal(
+
     portal: Portal,
     actor: Actor
+
 ) -> Any:
-    """Pull final result from portal (assuming it has one).
+    '''
+    Pull final result from portal (assuming it has one).
 
     If the main task is an async generator do our best to consume
     what's left of it.
-    """
+    '''
     try:
         log.debug(f"Waiting on final result from {actor.uid}")
 
@@ -126,18 +129,19 @@ async def exhaust_portal(
 
 
 async def cancel_on_completion(
+
     portal: Portal,
     actor: Actor,
     errors: Dict[Tuple[str, str], Exception],
 
 ) -> None:
-    """
+    '''
     Cancel actor gracefully once it's "main" portal's
     result arrives.
 
     Should only be called for actors spawned with `run_in_actor()`.
 
-    """
+    '''
     # if this call errors we store the exception for later
     # in ``errors`` which will be reraised inside
     # a MultiError and we still send out a cancel request

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -203,7 +203,6 @@ async def soft_wait(
     # which will kill any waiting remote pdb trace).
     # This is a "soft" (cancellable) join/reap.
     try:
-        # await proc.wait()
         await wait_func(proc)
     except trio.Cancelled:
         # if cancelled during a soft wait, cancel the child


### PR DESCRIPTION
This finally adds fully acknowledged remote cancellation messaging support for both explicit `Portal.cancel_actor()` calls as well as the same for runtime-wide cancellations (eg. during kbi or general actor nursery exception handling).

You can think of this as the *most ideal case* in [2-generals](https://en.wikipedia.org/wiki/Two_Generals%27_Problem#Engineering_approaches) where the actor requesting the cancel of its child is able to always receive back the ACK to that request. This leads to a more deterministic teardown where the parent is able to wait for the child to fully respond to the request. On a localhost setup (where the parent can monitor the state of the child through process or other OS apis instead of solely through messaging) the first parent can know whether or not the child decided to cancel with more certainty.

Implementation details:
- added `MsgStream.drain()`: an async iterator method that allows for pulling remaining messages out of a channel even if the channel processing was stopped due to runtime cancellation
  - [x] need to possibly update the typing protocol to include this?
- block msg loop processing tasks from closing channels if the channel is known to be attached to a child actor spawned in a local nursery such that any nursery triggered `Portal.cancel_actor()` call has time to send back a response and the runtime can collect and push that response msg to the calling task (whether in the nursery or a manual call). 
- add a `timeout` arg to `Portal.cancel_actor()` and tweak timeout block settings
- add a `ActorNursery.exited()` event to detect local nursery closure from other tasks


Oh and i added a buncha doc string tweaks i'm sure y'all gonna get mad about 😂  