### PR TITLE
End of channel fixes for streams and broadcasting

### DIFF
--- a/newsfragments/278.bug.rst
+++ b/newsfragments/278.bug.rst
@@ -1,0 +1,12 @@
+Repair inter-actor stream closure semantics to work correctly with
+``tractor.trionics.BroadcastReceiver`` task fan out usage.
+
+A set of previously unknown bugs discovered in `257
+<https://github.com/goodboy/tractor/pull/257>`_ let graceful stream
+closure result in hanging consumer tasks that use the broadcast APIs.
+This adds better internal closure state tracking to the broadcast
+receiver and message stream APIs and in particular ensures that when an
+underlying stream/receive-channel (a broadcast receiver is receiving
+from) is closed, all consumer tasks waiting on that underlying channel
+are woken so they can receive the ``trio.EndOfChannel`` signal and
+promptly terminate.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 pytest
 pytest-trio
 pdbpp
-mypy
+mypy<0.920
 trio_typing
 pexpect
 towncrier

--- a/tractor/_streaming.py
+++ b/tractor/_streaming.py
@@ -186,6 +186,7 @@ class ReceiveMsgStream(trio.abc.ReceiveChannel):
             # https://trio.readthedocs.io/en/stable/reference-io.html#trio.abc.AsyncResource.aclose
             return
 
+        self._eoc = True
         self._closed = True
 
         # NOTE: this is super subtle IPC messaging stuff:

--- a/tractor/_streaming.py
+++ b/tractor/_streaming.py
@@ -78,6 +78,7 @@ class ReceiveMsgStream(trio.abc.ReceiveChannel):
 
         # flag to denote end of stream
         self._eoc: bool = False
+        self._closed: bool = False
 
     # delegate directly to underlying mem channel
     def receive_nowait(self):
@@ -98,7 +99,7 @@ class ReceiveMsgStream(trio.abc.ReceiveChannel):
             msg = await self._rx_chan.receive()
             return msg['yield']
 
-        except KeyError:
+        except KeyError as err:
             # internal error should never get here
             assert msg.get('cid'), ("Received internal error at portal?")
 
@@ -107,8 +108,14 @@ class ReceiveMsgStream(trio.abc.ReceiveChannel):
             # - 'error'
             # possibly just handle msg['stop'] here!
 
-            if msg.get('stop'):
+            if msg.get('stop') or self._eoc:
                 log.debug(f"{self} was stopped at remote end")
+
+                # XXX: important to set so that a new ``.receive()``
+                # call (likely by another task using a broadcast receiver)
+                # doesn't accidentally pull the ``return`` message
+                # value out of the underlying feed mem chan!
+                self._eoc = True
 
                 # # when the send is closed we assume the stream has
                 # # terminated and signal this local iterator to stop
@@ -117,7 +124,7 @@ class ReceiveMsgStream(trio.abc.ReceiveChannel):
                 # XXX: this causes ``ReceiveChannel.__anext__()`` to
                 # raise a ``StopAsyncIteration`` **and** in our catch
                 # block below it will trigger ``.aclose()``.
-                raise trio.EndOfChannel
+                raise trio.EndOfChannel from err
 
             # TODO: test that shows stream raising an expected error!!!
             elif msg.get('error'):
@@ -162,10 +169,11 @@ class ReceiveMsgStream(trio.abc.ReceiveChannel):
             raise  # propagate
 
     async def aclose(self):
-        """Cancel associated remote actor task and local memory channel
-        on close.
+        '''
+        Cancel associated remote actor task and local memory channel on
+        close.
 
-        """
+        '''
         # XXX: keep proper adherance to trio's `.aclose()` semantics:
         # https://trio.readthedocs.io/en/stable/reference-io.html#trio.abc.AsyncResource.aclose
         rx_chan = self._rx_chan
@@ -178,7 +186,7 @@ class ReceiveMsgStream(trio.abc.ReceiveChannel):
             # https://trio.readthedocs.io/en/stable/reference-io.html#trio.abc.AsyncResource.aclose
             return
 
-        self._eoc = True
+        self._closed = True
 
         # NOTE: this is super subtle IPC messaging stuff:
         # Relay stop iteration to far end **iff** we're
@@ -310,14 +318,15 @@ class MsgStream(ReceiveMsgStream, trio.abc.Channel):
         self,
         data: Any
     ) -> None:
-        '''Send a message over this stream to the far end.
+        '''
+        Send a message over this stream to the far end.
 
         '''
-        # if self._eoc:
-        #     raise trio.ClosedResourceError('This stream is already ded')
-
         if self._ctx._error:
             raise self._ctx._error  # from None
+
+        if self._closed:
+            raise trio.ClosedResourceError('This stream was already closed')
 
         await self._ctx.chan.send({'yield': data, 'cid': self._ctx.cid})
 

--- a/tractor/trionics/_broadcast.py
+++ b/tractor/trionics/_broadcast.py
@@ -222,7 +222,10 @@ class BroadcastReceiver(ReceiveChannel):
                 event.set()
                 return value
 
-            except trio.Cancelled:
+            except (
+                trio.Cancelled,
+                trio.EndOfChannel,
+            ):
                 # handle cancelled specially otherwise sibling
                 # consumers will be awoken with a sequence of -1
                 # state.recv_ready = trio.Cancelled
@@ -274,11 +277,12 @@ class BroadcastReceiver(ReceiveChannel):
     async def subscribe(
         self,
     ) -> AsyncIterator[BroadcastReceiver]:
-        '''Subscribe for values from this broadcast receiver.
+        '''
+        Subscribe for values from this broadcast receiver.
 
         Returns a new ``BroadCastReceiver`` which is registered for and
-        pulls data from a clone of the original ``trio.abc.ReceiveChannel``
-        provided at creation.
+        pulls data from a clone of the original
+        ``trio.abc.ReceiveChannel`` provided at creation.
 
         '''
         if self._closed:


### PR DESCRIPTION
This patch set is factored out of #257 and corrects a bunch of previously unknown bugs to do with stream closure and broadcast receiver usage around streams as provided by `MsgStream.subscribe()`.

I decided to pull the work out of the other PR because this is notably different work despite discovering it via the original cached-inter-actor stream test that found it.

Summary:
- add a `MsgStream._closed: bool` for internal closure tracking and raise `trio.ClosedResourceError` in `.send()` if set 
- always set `MsgStream._eoc: bool` inside `.aclose()`
- always set `._eoc` when a `'stop'` message is received
- add `.eoc: bool` and `.cancelled: bool` tracking inside `BroadcastState`, set these flags on handling of the appropriate `trio` exceptions as well as wake all broadcast consumers on each signal to avoid hangs when a wrapped recv channel has closed via `trio.EndOfChannel`
- add a full task-broadcast inter-actor streaming test that verifies all of the above is now correct and graceful closure of the stream results in closure of all consumer tasks which entered `.subscribe()`