### PR TITLE
Add back latest mypy since `trio-typing` 0.7.0 is now compat

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 pytest
 pytest-trio
 pdbpp
-mypy<0.920
+mypy
 trio_typing
 pexpect
 towncrier


### PR DESCRIPTION
After https://github.com/python-trio/trio-typing/issues/50 was fixed but now we have more errors from latest `mypy` 😂 

Lurkerz help!