### PR TITLE
Cancel the `.cancel_actor()` request on proc death

### DIFF
--- a/nooz/248.misc.rst
+++ b/nooz/248.misc.rst
@@ -1,0 +1,8 @@
+Adjust the `tractor._spawn.soft_wait()` strategy to avoid sending an
+actor cancel request (via `Portal.cancel_actor()`) if either the child
+process is detected as having terminated or the IPC channel is detected
+to be closed.
+
+This ensures (even) more deterministic inter-actor cancellation by
+avoiding the timeout condition where possible when a whild never
+sucessfully spawned, crashed, or became un-contactable over IPC.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('docs/README.rst', encoding='utf-8') as f:
 
 setup(
     name="tractor",
-    version='0.1.0a4',  # alpha zone
+    version='0.1.0a5.dev',  # alpha zone
     description='structured concurrrent "actors"',
     long_description=readme,
     license='GPLv3',

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -526,7 +526,7 @@ async def mp_new_proc(
 
         # XXX: monkey patch poll API to match the ``subprocess`` API..
         # not sure why they don't expose this but kk.
-        proc.poll = proc._popen.poll  # type: ignore
+        proc.poll = lambda: proc.exitcode  # type: ignore
 
     # except:
         # TODO: in the case we were cancelled before the sub-proc

--- a/tractor/trionics/_mngrs.py
+++ b/tractor/trionics/_mngrs.py
@@ -170,7 +170,6 @@ async def maybe_open_context(
     await _Cache.lock.acquire()
 
     ctx_key = (id(acm_func), key or tuple(kwargs.items()))
-    print(ctx_key)
     value = None
 
     try:
@@ -180,7 +179,7 @@ async def maybe_open_context(
         value = _Cache.values[ctx_key]
 
     except KeyError:
-        log.info(f'Allocating new resource for {ctx_key}')
+        log.info(f'Allocating new {acm_func} for {ctx_key}')
 
         mngr = acm_func(**kwargs)
         # TODO: avoid pulling from ``tractor`` internals and


### PR DESCRIPTION
Adjust the `soft_wait()` strategy to avoid sending needless cancel
requests if suitable.

Basically an even more graceful handling of actor cancellation for parent-child peers.