### PR TITLE
`NamespacePath`: a message compatible "object reference" type

### DIFF
--- a/nooz/295.misc.rst
+++ b/nooz/295.misc.rst
@@ -1,0 +1,3 @@
+Add an experimental `tractor.msg.NamespacePath` type for passing Python
+objects by "reference" through a ``str``-subtype message and using the
+new ``pkgutil.resolve_name()`` for reference loading.

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -82,7 +82,7 @@ class NamespacePath(str):
 
     ) -> tuple[str, str]:
         ref = self.load_ref()
-        return ref.__module__, ref.__name__
+        return ref.__module__, getattr(ref, '__name__', '')
 
     @classmethod
     def from_ref(

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -21,7 +21,6 @@ concurrency linked tasks running in disparate memory domains.
 '''
 from __future__ import annotations
 import importlib
-from pkgutil import resolve_name
 import inspect
 from typing import (
     Any, Optional,
@@ -38,6 +37,7 @@ from async_generator import asynccontextmanager
 from ._state import current_actor
 from ._ipc import Channel
 from .log import get_logger
+from .msg import NamespacePath
 from ._exceptions import (
     unpack_error,
     NoResult,
@@ -66,34 +66,6 @@ async def maybe_open_nursery(
         async with trio.open_nursery() as nursery:
             nursery.cancel_scope.shield = shield
             yield nursery
-
-
-class NamespacePath(str):
-    '''
-    A serializeable description of a (function) Python object location
-    described by the target's module path and its namespace key.
-
-    '''
-    def load_ref(self) -> object:
-        return resolve_name(self)
-
-    def to_tuple(
-        self,
-
-    ) -> tuple[str, str]:
-        ref = self.load_ref()
-        return ref.__module__, getattr(ref, '__name__', '')
-
-    @classmethod
-    def from_ref(
-        cls,
-        obj,
-
-    ) -> NamespacePath:
-        return cls(':'.join(
-            (obj.__module__,
-             obj.__name__,)
-        ))
 
 
 def _unwrap_msg(

--- a/tractor/msg.py
+++ b/tractor/msg.py
@@ -15,6 +15,55 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
-Coming soon!
+Built-in messaging patterns, types, APIs and helpers.
 
 '''
+
+# TODO: integration with our ``enable_modules: list[str]`` caps sys.
+
+# ``pkgutil.resolve_name()`` internally uses
+# ``importlib.import_module()`` which can be filtered by inserting
+# a ``MetaPathFinder`` into ``sys.meta_path`` (which we could do before
+# entering the ``Actor._process_messages()`` loop).
+# - https://github.com/python/cpython/blob/main/Lib/pkgutil.py#L645
+# - https://stackoverflow.com/questions/1350466/preventing-python-code-from-importing-certain-modules
+#   - https://stackoverflow.com/a/63320902
+#   - https://docs.python.org/3/library/sys.html#sys.meta_path
+
+# the new "Implicit Namespace Packages" might be relevant?
+# - https://www.python.org/dev/peps/pep-0420/
+
+from __future__ import annotations
+from pkgutil import resolve_name
+
+
+class NamespacePath(str):
+    '''
+    A serializeable description of a (function) Python object location
+    described by the target's module path and its namespace key.
+
+    '''
+    _ref: object = None
+
+    def load_ref(self) -> object:
+        if self._ref is None:
+            self._ref = resolve_name(self)
+        return self._ref
+
+    def to_tuple(
+        self,
+
+    ) -> tuple[str, str]:
+        ref = self.load_ref()
+        return ref.__module__, getattr(ref, '__name__', '')
+
+    @classmethod
+    def from_ref(
+        cls,
+        ref,
+
+    ) -> NamespacePath:
+        return cls(':'.join(
+            (ref.__module__,
+             getattr(ref, '__name__', ''))
+        ))

--- a/tractor/msg.py
+++ b/tractor/msg.py
@@ -49,7 +49,9 @@ from pkgutil import resolve_name
 class NamespacePath(str):
     '''
     A serializeable description of a (function) Python object location
-    described by the target's module path and its namespace key.
+    described by the target's module path and namespace key meant as
+    a message-native "packet" to allows actors to point-and-load objects
+    by absolute reference.
 
     '''
     _ref: object = None

--- a/tractor/msg.py
+++ b/tractor/msg.py
@@ -33,6 +33,15 @@ Built-in messaging patterns, types, APIs and helpers.
 # the new "Implicit Namespace Packages" might be relevant?
 # - https://www.python.org/dev/peps/pep-0420/
 
+# add implicit serialized message type support so that paths can be
+# handed directly to IPC primitives such as streams and `Portal.run()`
+# calls:
+# - via ``msgspec``:
+#   - https://jcristharif.com/msgspec/api.html#struct
+#   - https://jcristharif.com/msgspec/extending.html
+# via ``msgpack-python``:
+# - https://github.com/msgpack/msgpack-python#packingunpacking-of-custom-data-type
+
 from __future__ import annotations
 from pkgutil import resolve_name
 


### PR DESCRIPTION
Discussion in #294 and looking for scrutiny and feedback on how this might play well with our `ActorNursery.start_actor(<name>, enable_modules:list[str])` module capability system.