### PR TITLE
Use lists by default like `msgspec`, update to latest `msgspec`  and `msgpack` releases

### DIFF
--- a/nooz/300.misc.rst
+++ b/nooz/300.misc.rst
@@ -1,3 +1,3 @@
-Update to and pin latest `msgpack-python` (0.5.6) and `msgspec` (0.4.0)
+Update to and pin latest `msgpack` (1.0.3) and `msgspec` (0.4.0)
 both of which required adjustments for backwards imcompatible API
 tweaks.

--- a/nooz/300.misc.rst
+++ b/nooz/300.misc.rst
@@ -1,0 +1,3 @@
+Update to and pin latest `msgpack-python` (0.5.6) and `msgspec` (0.4.0)
+both of which required adjustments for backwards imcompatible API
+tweaks.

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'pdbpp',
 
         # serialization
-        'msgpack',
+        'msgpack>=1.0.3',
 
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     extras_require={
 
         # serialization
-        'msgspec': ["msgspec >= 0.3.2'; python_version >= '3.9'"],
+        'msgspec': ['msgspec >= "0.4.0"'],
 
     },
     tests_require=['pytest'],

--- a/tractor/_actor.py
+++ b/tractor/_actor.py
@@ -1502,7 +1502,7 @@ class Arbiter(Actor):
     async def get_registry(
         self
 
-    ) -> dict[tuple[str, str], tuple[str, int]]:
+    ) -> dict[str, tuple[str, int]]:
         '''
         Return current name registry.
 

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -222,8 +222,8 @@ class MsgspecTCPStream(MsgpackTCPStream):
         self.prefix_size = prefix_size
 
         # TODO: struct aware messaging coders
-        self.encode = msgspec.Encoder().encode
-        self.decode = msgspec.Decoder().decode  # dict[str, Any])
+        self.encode = msgspec.msgpack.Encoder().encode
+        self.decode = msgspec.msgpack.Decoder().decode  # dict[str, Any])
 
     async def _iter_packets(self) -> AsyncGenerator[dict, None]:
         '''Yield packets from the underlying stream.

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -121,11 +121,12 @@ class MsgpackTCPStream:
         self.drained: list[dict] = []
 
     async def _iter_packets(self) -> AsyncGenerator[dict, None]:
-        """Yield packets from the underlying stream.
-        """
+        '''
+        Yield packets from the underlying stream.
+
+        '''
         unpacker = msgpack.Unpacker(
             raw=False,
-            strict_map_key=False
         )
         while True:
             try:

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -96,7 +96,8 @@ class MsgTransport(Protocol[MsgType]):
 
 
 class MsgpackTCPStream:
-    '''A ``trio.SocketStream`` delivering ``msgpack`` formatted data
+    '''
+    A ``trio.SocketStream`` delivering ``msgpack`` formatted data
     using ``msgpack-python``.
 
     '''
@@ -124,7 +125,6 @@ class MsgpackTCPStream:
         """
         unpacker = msgpack.Unpacker(
             raw=False,
-            use_list=False,
             strict_map_key=False
         )
         while True:

--- a/tractor/trionics/_mngrs.py
+++ b/tractor/trionics/_mngrs.py
@@ -71,7 +71,7 @@ async def gather_contexts(
 
     mngrs: Sequence[AsyncContextManager[T]],
 
-) -> AsyncGenerator[tuple[T, ...], None]:
+) -> AsyncGenerator[tuple[Optional[T], ...], None]:
     '''
     Concurrently enter a sequence of async context managers, each in
     a separate ``trio`` task and deliver the unwrapped values in the
@@ -84,7 +84,7 @@ async def gather_contexts(
     entered and exited cancellation just works.
 
     '''
-    unwrapped = {}.fromkeys(id(mngr) for mngr in mngrs)
+    unwrapped: dict[int, Optional[T]] = {}.fromkeys(id(mngr) for mngr in mngrs)
 
     all_entered = trio.Event()
     parent_exit = trio.Event()


### PR DESCRIPTION
As per https://github.com/jcrist/msgspec/issues/30#issuecomment-869084723 there's not much of a benefit in our use case (IPC messaging often with dynamic lists) and we can always (and are planning to) support native structs eventually anyway.

The further benefit is that we can assume `msgspec` and `msgpack` will be uniform in the array format after decode. 

Relates to https://github.com/goodboy/tractor/issues/196 and https://github.com/goodboy/tractor/issues/294.