### PR TITLE
Fence mp

### DIFF
--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -264,7 +264,7 @@ class MsgspecTCPStream(MsgpackTCPStream):
             try:
                 yield self.decode(msg_bytes)
             except (
-                msgspec.DecodingError,
+                msgspec.DecodeError,
                 UnicodeDecodeError,
             ):
                 if not last_decode_failed:

--- a/tractor/_mp_fixup_main.py
+++ b/tractor/_mp_fixup_main.py
@@ -18,9 +18,9 @@
 Helpers pulled mostly verbatim from ``multiprocessing.spawn``
 to aid with "fixing up" the ``__main__`` module in subprocesses.
 
-These helpers are needed for any spawing backend that doesn't already handle this.
-For example when using ``trio_run_in_process`` it is needed but obviously not when
-we're already using ``multiprocessing``.
+These helpers are needed for any spawing backend that doesn't already
+handle this. For example when using ``trio_run_in_process`` it is needed
+but obviously not when we're already using ``multiprocessing``.
 
 """
 import os
@@ -28,13 +28,12 @@ import sys
 import platform
 import types
 import runpy
-from typing import Dict
 
 
 ORIGINAL_DIR = os.path.abspath(os.getcwd())
 
 
-def _mp_figure_out_main() -> Dict[str, str]:
+def _mp_figure_out_main() -> dict[str, str]:
     """Taken from ``multiprocessing.spawn.get_preparation_data()``.
 
     Retrieve parent actor `__main__` module data.

--- a/tractor/_state.py
+++ b/tractor/_state.py
@@ -20,7 +20,6 @@ Per process state
 """
 from typing import Optional, Dict, Any
 from collections.abc import Mapping
-import multiprocessing as mp
 
 import trio
 
@@ -71,6 +70,7 @@ class ActorContextInfo(Mapping):
 def is_main_process() -> bool:
     """Bool determining if this actor is running in the top-most process.
     """
+    import multiprocessing as mp
     return mp.current_process().name == 'MainProcess'
 
 

--- a/tractor/_supervise.py
+++ b/tractor/_supervise.py
@@ -20,8 +20,7 @@
 """
 from functools import partial
 import inspect
-import multiprocessing as mp
-from typing import Tuple, List, Dict, Optional
+from typing import Tuple, List, Dict, Optional, TYPE_CHECKING
 import typing
 import warnings
 
@@ -38,6 +37,9 @@ from ._root import open_root_actor
 from . import _state
 from . import _spawn
 
+
+if TYPE_CHECKING:
+    import multiprocessing as mp
 
 log = get_logger(__name__)
 


### PR DESCRIPTION
Bare bones attempt at avoiding import of `multiprocessing` until absolutely necessary mostly to avoid
any side effects present in the `resource_tracker` module.