### PR TITLE
Add `tractor.query_actor()` an addr looker-upper

### DIFF
--- a/305.misc.rst
+++ b/305.misc.rst
@@ -1,0 +1,7 @@
+Add ``tractor.query_actor()`` an addr looker-upper which doesn't deliver
+a ``Portal`` instance and instead just a socket address ``tuple``.
+
+Sometimes it's handy to just have a simple way to figure out if
+a "service" actor is up, so add this discovery helper for that. We'll
+prolly just leave it undocumented for now until we figure out
+a longer-term/better discovery system.

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -29,7 +29,12 @@ from ._streaming import (
     stream,
     context,
 )
-from ._discovery import get_arbiter, find_actor, wait_for_actor
+from ._discovery import (
+    get_arbiter,
+    find_actor,
+    wait_for_actor,
+    query_actor,
+)
 from ._supervise import open_nursery
 from ._state import current_actor, is_root_process
 from ._exceptions import (
@@ -46,11 +51,15 @@ from ._portal import Portal
 __all__ = [
     'Channel',
     'Context',
-    'ModuleNotExposed',
-    'MultiError',
-    'RemoteActorError',
     'ContextCancelled',
+    'ModuleNotExposed',
+    'MsgStream',
+    'MultiError',
+    'Portal',
+    'ReceiveMsgStream',
+    'RemoteActorError',
     'breakpoint',
+    'context',
     'current_actor',
     'find_actor',
     'get_arbiter',
@@ -59,14 +68,11 @@ __all__ = [
     'open_actor_cluster',
     'open_nursery',
     'open_root_actor',
-    'Portal',
     'post_mortem',
+    'query_actor',
     'run',
     'run_daemon',
     'stream',
-    'context',
-    'ReceiveMsgStream',
-    'MsgStream',
     'to_asyncio',
     'wait_for_actor',
 ]

--- a/tractor/_discovery.py
+++ b/tractor/_discovery.py
@@ -18,8 +18,7 @@
 Actor discovery API.
 
 """
-import typing
-from typing import Tuple, Optional, Union
+from typing import Tuple, Optional, Union, AsyncGenerator
 from contextlib import asynccontextmanager as acm
 
 from ._ipc import _connect_chan, Channel
@@ -37,7 +36,7 @@ async def get_arbiter(
     host: str,
     port: int,
 
-) -> typing.AsyncGenerator[Union[Portal, LocalPortal], None]:
+) -> AsyncGenerator[Union[Portal, LocalPortal], None]:
     '''Return a portal instance connected to a local or remote
     arbiter.
     '''
@@ -61,7 +60,7 @@ async def get_arbiter(
 @acm
 async def get_root(
     **kwargs,
-) -> typing.AsyncGenerator[Portal, None]:
+) -> AsyncGenerator[Portal, None]:
 
     host, port = _runtime_vars['_root_mailbox']
     assert host is not None
@@ -74,9 +73,9 @@ async def get_root(
 @acm
 async def query_actor(
     name: str,
-    arbiter_sockaddr: Tuple[str, int] = None,
+    arbiter_sockaddr: Optional[tuple[str, int]] = None,
 
-) -> tuple[str, int]:
+) -> AsyncGenerator[tuple[str, int], None]:
     '''
     Simple address lookup for a given actor name.
 
@@ -107,7 +106,7 @@ async def find_actor(
     name: str,
     arbiter_sockaddr: Tuple[str, int] = None
 
-) -> typing.AsyncGenerator[Optional[Portal], None]:
+) -> AsyncGenerator[Optional[Portal], None]:
     '''
     Ask the arbiter to find actor(s) by name.
 
@@ -132,7 +131,7 @@ async def find_actor(
 async def wait_for_actor(
     name: str,
     arbiter_sockaddr: Tuple[str, int] = None
-) -> typing.AsyncGenerator[Portal, None]:
+) -> AsyncGenerator[Portal, None]:
     """Wait on an actor to register with the arbiter.
 
     A portal to the first registered actor is returned.


### PR DESCRIPTION
Sometimes it's handy to just have a non-`Portal` yielding way
to figure out if a "service" actor is up, so add this discovery
helper for that. We'll prolly just leave it undocumented for
now until we figure out a longer-term/better discovery system.