### PR TITLE
Sort `.subscribe()` results before comparison

### DIFF
--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -280,14 +280,19 @@ async def stream_from_aio(
                 # we get double the pulled values in the
                 # ``.subscribe()`` fan out case.
                 doubled = list(itertools.chain(*zip(expect, expect)))
-                if pulled != doubled[:len(pulled)]:
-                    print(f'uhhh pulled is {pulled}')
-                    assert pulled == doubled[:len(pulled)]
+                expect = doubled[:len(pulled)]
+                if list(sorted(pulled)) != expect:
+                    print(
+                        f'uhhh pulled is {pulled}\n',
+                        f'uhhh expect is {expect}\n',
+                    )
+
+                assert pulled == expect
 
             else:
                 assert pulled == expect
         else:
-            # if fan_out:
+            assert not fan_out
             assert pulled == expect[:51]
 
         print('trio guest mode task completed!')


### PR DESCRIPTION
Post-op from #304 just to get the test more reliable since windows has order issues apparently likely due to slight scheduling/latency differences.. 