### PR TITLE
Sort `.subscribe()` results before comparison in test

### DIFF
--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -281,12 +281,7 @@ async def stream_from_aio(
                 # ``.subscribe()`` fan out case.
                 doubled = list(itertools.chain(*zip(expect, expect)))
                 expect = doubled[:len(pulled)]
-                if pulled != expect:
-                    print(
-                        f'uhhh pulled is {pulled}\n',
-                        f'uhhh expect is {expect}\n',
-                    )
-                    assert pulled == expect
+                assert list(sorted(pulled)) == expect
 
             else:
                 assert pulled == expect


### PR DESCRIPTION
Post-op from https://github.com/goodboy/tractor/pull/304 just to get the test more reliable since windows has order issues apparently likely due to slight scheduling/latency differences..