### PR TITLE
Add context test that opens an inter-task-channel that errors

### DIFF
--- a/examples/infected_asyncio_echo_server.py
+++ b/examples/infected_asyncio_echo_server.py
@@ -13,6 +13,7 @@ import tractor
 async def aio_echo_server(
     to_trio: trio.MemorySendChannel,
     from_trio: asyncio.Queue,
+
 ) -> None:
 
     # a first message must be sent **from** this ``asyncio``

--- a/nooz/318.bug.rst
+++ b/nooz/318.bug.rst
@@ -1,0 +1,13 @@
+Fix a previously undetected ``trio``-``asyncio`` task lifetime linking
+issue with the ``to_asyncio.open_channel_from()`` api where both sides
+where not properly waiting/signalling termination and it was possible
+for ``asyncio``-side errors to not propagate due to a race condition.
+
+The implementation fix summary is:
+- add state to signal the end of the ``trio`` side task to be
+  read by the ``asyncio`` side and always cancel any ongoing
+  task in such cases.
+- always wait on the ``asyncio`` task termination from the ``trio``
+  side on error before maybe raising said error.
+- always close the ``trio`` mem chan on exit to ensure the other
+  side can detect it and follow.

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -185,7 +185,7 @@ async def trio_ctx(
                 tractor.to_asyncio.run_task,
                 sleep_forever,
             )
-            # await trio.sleep_forever()
+            await trio.sleep_forever()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -14,7 +14,6 @@ import tractor
 from tractor import (
     to_asyncio,
     RemoteActorError,
-    ContextCancelled
 )
 from tractor.trionics import BroadcastReceiver
 
@@ -199,7 +198,7 @@ def test_context_spawns_aio_task_that_errors(
     '''
     Verify that spawning a task via an intertask channel ctx mngr that
     errors correctly propagates the error back from the `asyncio`-side
-    taksk.
+    task.
 
     '''
     async def main():
@@ -222,7 +221,6 @@ def test_context_spawns_aio_task_that_errors(
                     await p.cancel_actor()
 
                 await trio.sleep_forever()
-
 
     with pytest.raises(RemoteActorError) as excinfo:
         trio.run(main)

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -169,7 +169,7 @@ async def trio_ctx(
 
     # this will block until the ``asyncio`` task sends a "first"
     # message.
-    with trio.fail_after(0.5):
+    with trio.fail_after(2):
         async with (
             tractor.to_asyncio.open_channel_from(
                 sleep_and_err,

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -23,7 +23,6 @@ from asyncio.exceptions import CancelledError
 from contextlib import asynccontextmanager as acm
 from dataclasses import dataclass
 import inspect
-import traceback
 from typing import (
     Any,
     Callable,
@@ -297,7 +296,7 @@ def _run_asyncio_task(
             elif task_err is None:
                 assert aio_err
                 aio_err.with_traceback(aio_err.__traceback__)
-                log.error(f'infected task errorred')
+                log.error('infected task errorred')
 
             # XXX: alway cancel the scope on error
             # in case the trio task is blocking

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -63,6 +63,7 @@ class LinkedTaskChannel(trio.abc.Channel):
 
     _trio_cs: trio.CancelScope
     _aio_task_complete: trio.Event
+    _trio_exited: bool = False
 
     # set after ``asyncio.create_task()``
     _aio_task: Optional[asyncio.Task] = None
@@ -73,7 +74,13 @@ class LinkedTaskChannel(trio.abc.Channel):
         await self._from_aio.aclose()
 
     async def receive(self) -> Any:
-        async with translate_aio_errors(self):
+        async with translate_aio_errors(
+            self,
+
+            # XXX: obviously this will deadlock if an on-going stream is
+            # being procesed.
+            # wait_on_aio_task=False,
+        ):
 
             # TODO: do we need this to guarantee asyncio code get's
             # cancelled in the case where the trio side somehow creates
@@ -210,10 +217,8 @@ def _run_asyncio_task(
         orig = result = id(coro)
         try:
             result = await coro
-        except GeneratorExit:
-            # no need to relay error
-            raise
         except BaseException as aio_err:
+            log.exception('asyncio task errored')
             chan._aio_err = aio_err
             raise
 
@@ -237,6 +242,7 @@ def _run_asyncio_task(
                 to_trio.close()
 
             aio_task_complete.set()
+            log.runtime(f'`asyncio` task: {task.get_name()} is complete')
 
     # start the asyncio task we submitted from trio
     if not inspect.isawaitable(coro):
@@ -296,6 +302,11 @@ def _run_asyncio_task(
                     f'infected task errorred:\n{msg}'
                 )
 
+            # XXX: alway cancel the scope on error
+            # in case the trio task is blocking
+            # on a checkpoint.
+            cancel_scope.cancel()
+
             # raise any ``asyncio`` side error.
             raise aio_err
 
@@ -307,6 +318,7 @@ def _run_asyncio_task(
 async def translate_aio_errors(
 
     chan: LinkedTaskChannel,
+    wait_on_aio_task: bool = False,
 
 ) -> AsyncIterator[None]:
     '''
@@ -318,6 +330,7 @@ async def translate_aio_errors(
 
     aio_err: Optional[BaseException] = None
 
+    # TODO: make thisi a channel method?
     def maybe_raise_aio_err(
         err: Optional[Exception] = None
     ) -> None:
@@ -367,13 +380,30 @@ async def translate_aio_errors(
             raise
 
     finally:
-        # always cancel the ``asyncio`` task if we've made it this far
-        # and it's not done.
-        if not task.done() and aio_err:
+        if (
+            # NOTE: always cancel the ``asyncio`` task if we've made it
+            # this far and it's not done.
+            not task.done() and aio_err
+
+            # or the trio side has exited it's surrounding cancel scope
+            # indicating the lifetime of the ``asyncio``-side task
+            # should also be terminated.
+            or chan._trio_exited
+        ):
+            log.runtime(
+                f'Cancelling `asyncio`-task: {chan._aio_taskget_name()}'
+            )
             # assert not aio_err, 'WTF how did asyncio do this?!'
             task.cancel()
 
-        # if any ``asyncio`` error was caught, raise it here inline
+        # Required to sync with the far end ``asyncio``-task to ensure
+        # any error is captured (via monkeypatching the
+        # ``channel._aio_err``) before calling ``maybe_raise_aio_err()``
+        # below!
+        if wait_on_aio_task:
+            await chan._aio_task_complete.wait()
+
+        # NOTE: if any ``asyncio`` error was caught, raise it here inline
         # here in the ``trio`` task
         maybe_raise_aio_err()
 
@@ -398,7 +428,10 @@ async def run_task(
         **kwargs,
     )
     with chan._from_aio:
-        async with translate_aio_errors(chan):
+        async with translate_aio_errors(
+            chan,
+            wait_on_aio_task=True,
+        ):
             # return single value that is the output from the
             # ``asyncio`` function-as-task. Expect the mem chan api to
             # do the job of handling cross-framework cancellations
@@ -426,13 +459,21 @@ async def open_channel_from(
         **kwargs,
     )
     async with chan._from_aio:
-        async with translate_aio_errors(chan):
+        async with translate_aio_errors(
+            chan,
+            wait_on_aio_task=True,
+        ):
             # sync to a "started()"-like first delivered value from the
             # ``asyncio`` task.
             first = await chan.receive()
 
             # deliver stream handle upward
-            yield first, chan
+            try:
+                with chan._trio_cs:
+                    yield first, chan
+            finally:
+                chan._trio_exited = True
+                chan._to_trio.close()
 
 
 def run_as_asyncio_guest(
@@ -482,7 +523,7 @@ def run_as_asyncio_guest(
                 main_outcome.unwrap()
             else:
                 trio_done_fut.set_result(main_outcome)
-                print(f"trio_main finished: {main_outcome!r}")
+                log.runtime(f"trio_main finished: {main_outcome!r}")
 
         # start the infection: run trio on the asyncio loop in "guest mode"
         log.info(f"Infecting asyncio process with {trio_main}")

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -388,7 +388,7 @@ async def translate_aio_errors(
             or chan._trio_exited
         ):
             log.runtime(
-                f'Cancelling `asyncio`-task: {chan._aio_task.get_name()}'
+                f'Cancelling `asyncio`-task: {task.get_name()}'
             )
             # assert not aio_err, 'WTF how did asyncio do this?!'
             task.cancel()

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -297,10 +297,7 @@ def _run_asyncio_task(
             elif task_err is None:
                 assert aio_err
                 aio_err.with_traceback(aio_err.__traceback__)
-                msg = ''.join(traceback.format_exception(type(aio_err)))
-                log.error(
-                    f'infected task errorred:\n{msg}'
-                )
+                log.error(f'infected task errorred')
 
             # XXX: alway cancel the scope on error
             # in case the trio task is blocking
@@ -391,7 +388,7 @@ async def translate_aio_errors(
             or chan._trio_exited
         ):
             log.runtime(
-                f'Cancelling `asyncio`-task: {chan._aio_taskget_name()}'
+                f'Cancelling `asyncio`-task: {chan._aio_task.get_name()}'
             )
             # assert not aio_err, 'WTF how did asyncio do this?!'
             task.cancel()


### PR DESCRIPTION
Turns out the `to_asyncio.` stuff wasn't robust enough to handle this;  we weren't propagating errors from an IPC context embedded task opened via `.open_channel_from()`..

---
To start this adds 2 more tests:
- [x] one where the far end `asyncio` task errors after a short sleep but this error is not propagated and the test times out.
  - [x] a fix will come for this in a follow up commit
- [x] one test that does pass where the parent actor that also opens the IPC context cancels the actor using the portal api.