### PR TITLE
Add debug complete event `None`-guard for when already reset

### DIFF
--- a/nooz/324.bugfix.rst
+++ b/nooz/324.bugfix.rst
@@ -1,0 +1,4 @@
+Only set `._debug.Lock.local_pdb_complete` if has been created.
+
+This can be triggered by a very rare race condition (and thus we have no
+working test yet) but it is known to exist in (a) consumer project(s).

--- a/tractor/_debug.py
+++ b/tractor/_debug.py
@@ -126,7 +126,8 @@ class Lock:
         try:
             # sometimes the ``trio`` might already be terminated in
             # which case this call will raise.
-            cls.local_pdb_complete.set()
+            if cls.local_pdb_complete is not None:
+                cls.local_pdb_complete.set()
         finally:
             # restore original sigint handler
             cls.unshield_sigint()


### PR DESCRIPTION
Tidbit case I missed in #165 where the completion event may have already been set back to `None` and we can get an attr error.. 