### PR TITLE
Disable win tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,9 @@ jobs:
       - name: Run tests
         run: pytest tests/ --spawn-backend=${{ matrix.spawn_backend }} -rsx
 
-  # We skip 3.10 on windows for now due to
-  # https://github.com/pytest-dev/pytest/issues/8733
-  # some kinda weird `pyreadline` issue..
+  # We skip 3.10 on windows for now due to not having any collabs to
+  # debug the CI failures. Anyone wanting to hack and solve them is very
+  # welcome, but our primary user base is not using that OS.
 
   # TODO: use job filtering to accomplish instead of repeated
   # boilerplate as is above XD:
@@ -114,6 +114,11 @@ jobs:
 
       - name: Install dependencies
         run: pip install -U . -r requirements-test.txt -r requirements-docs.txt --upgrade-strategy eager
+
+      # TODO: pretty sure this solves debugger deps-issues on windows, but it needs to
+      # be verified by someone with a native setup.
+      # - name: Force pyreadline3
+      #   run: pip uninstall pyreadline; pip install -U pyreadline3
 
       - name: List dependencies
         run: pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,38 +90,38 @@ jobs:
   # - https://docs.github.com/en/actions/learn-github-actions/managing-complex-workflows
   # - https://docs.github.com/en/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
   # - https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idif
-  testing-windows:
-    name: '${{ matrix.os }} Python ${{ matrix.python }} - ${{ matrix.spawn_backend }}'
-    timeout-minutes: 12
-    runs-on: ${{ matrix.os }}
+  # testing-windows:
+  #   name: '${{ matrix.os }} Python ${{ matrix.python }} - ${{ matrix.spawn_backend }}'
+  #   timeout-minutes: 12
+  #   runs-on: ${{ matrix.os }}
 
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest]
-        python: ['3.10']
-        spawn_backend: ['trio', 'mp']
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [windows-latest]
+  #       python: ['3.10']
+  #       spawn_backend: ['trio', 'mp']
 
-    steps:
+  #   steps:
 
-      - name: Checkout
-        uses: actions/checkout@v2
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
 
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '${{ matrix.python }}'
+  #     - name: Setup python
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: '${{ matrix.python }}'
 
-      - name: Install dependencies
-        run: pip install -U . -r requirements-test.txt -r requirements-docs.txt --upgrade-strategy eager
+  #     - name: Install dependencies
+  #       run: pip install -U . -r requirements-test.txt -r requirements-docs.txt --upgrade-strategy eager
 
-      # TODO: pretty sure this solves debugger deps-issues on windows, but it needs to
-      # be verified by someone with a native setup.
-      # - name: Force pyreadline3
-      #   run: pip uninstall pyreadline; pip install -U pyreadline3
+  #     # TODO: pretty sure this solves debugger deps-issues on windows, but it needs to
+  #     # be verified by someone with a native setup.
+  #     # - name: Force pyreadline3
+  #     #   run: pip uninstall pyreadline; pip install -U pyreadline3
 
-      - name: List dependencies
-        run: pip list
+  #     - name: List dependencies
+  #       run: pip list
 
-      - name: Run tests
-        run: pytest tests/ --spawn-backend=${{ matrix.spawn_backend }} -rsx
+  #     - name: Run tests
+  #       run: pytest tests/ --spawn-backend=${{ matrix.spawn_backend }} -rsx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ['3.9', '3.10']
+        python: ['3.10']
         spawn_backend: ['trio', 'mp']
 
     steps:
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        python: ['3.9', '3.10']
+        python: ['3.10']
         spawn_backend: ['trio', 'mp']
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Run MyPy check
         run: mypy tractor/ --ignore-missing-imports
 
+  # test that we can generate a software distribution and install it
+  # thus avoid missing file issues after packaging.
   sdist-linux:
     name: 'sdist'
     runs-on: ubuntu-latest
@@ -74,7 +76,7 @@ jobs:
         run: pip install -U . -r requirements-test.txt -r requirements-docs.txt --upgrade-strategy eager
 
       - name: List dependencies
-        run: pip freeze
+        run: pip list
 
       - name: Run tests
         run: pytest tests/ --spawn-backend=${{ matrix.spawn_backend }} -rsx
@@ -114,7 +116,7 @@ jobs:
         run: pip install -U . -r requirements-test.txt -r requirements-docs.txt --upgrade-strategy eager
 
       - name: List dependencies
-        run: pip freeze
+        run: pip list
 
       - name: Run tests
-        run: pytest tests/ --spawn-backend=${{ matrix.spawn_backend }} -rs --full-trace
+        run: pytest tests/ --spawn-backend=${{ matrix.spawn_backend }} -rsx

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -568,8 +568,8 @@ Help us push toward the future of distributed `Python`.
   <https://github.com/goodboy/tractor/issues/196>`_ with draft work
   started in `#311 <https://github.com/goodboy/tractor/pull/311>`_)
 - We **recently disabled CI-testing on windows** and need help getting
-  it running again! (see `#322
-  <https://github.com/goodboy/tractor/pull/322>`_). **We do have windows
+  it running again! (see `#327
+  <https://github.com/goodboy/tractor/pull/327>`_). **We do have windows
   support** (and have for quite a while) but since no active hacker
   exists in the user-base to help test on that OS, for now we're not
   actively maintaining testing due to the added hassle and general

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -567,6 +567,13 @@ Help us push toward the future of distributed `Python`.
 - Typed capability-based (dialog) protocols ( see `#196
   <https://github.com/goodboy/tractor/issues/196>`_ with draft work
   started in `#311 <https://github.com/goodboy/tractor/pull/311>`_)
+- We **recently disabled CI-testing on windows** and need help getting
+  it running again! (see `#322
+  <https://github.com/goodboy/tractor/pull/322>`_). **We do have windows
+  support** (and have for quite a while) but since no active hacker
+  exists in the user-base to help test on that OS, for now we're not
+  actively maintaining testing due to the added hassle and general
+  latency..
 
 
 Feel like saying hi?


### PR DESCRIPTION
Factoring out the history from #322 since we have other PRs which also need this to run clean 😂.

Also makes it easier to reference this specific change.

---
### GRAND SUMMARY
We are **disabling windows from CI** since there are clearly a few [unexpected (and frankly unexplainable) regressions](https://github.com/goodboy/tractor/actions/runs/3000118896/jobs/4814595104) which seem to be mostly due to windows runs getting **even slower** yet again (see streaming test fixtures) and we have no collaborator actively hacking on the *great tina OS*. 

So until we get someone who cares, we're disabling it all.
We are of course leaving in the existing support but there's no guarantees about functionality or correctness until someone comes who can verify it and help fix it 😂 (hint @chrizzFTD)..

In other words it's kinda pointless to keep caring, hacking, tweaking timeouts if no-one is actually going to complain at us for stuff being windowsy..