### PR TITLE
`ExceptiongGroup`s and `trio>=0.22`

### DIFF
--- a/examples/debugging/multi_daemon_subactors.py
+++ b/examples/debugging/multi_daemon_subactors.py
@@ -27,7 +27,18 @@ async def main():
 
         # retreive results
         async with p0.open_stream_from(breakpoint_forever) as stream:
-            await p1.run(name_error)
+
+            # triggers the first name error
+            try:
+                await p1.run(name_error)
+            except tractor.RemoteActorError as rae:
+                assert rae.type is NameError
+
+            async for i in stream:
+
+                # a second time try the failing subactor and this tie
+                # let error propagate up to the parent/nursery.
+                await p1.run(name_error)
 
 
 if __name__ == '__main__':

--- a/nooz/333.feature.rst
+++ b/nooz/333.feature.rst
@@ -1,0 +1,25 @@
+Add support for ``trio >= 0.22`` and support for the new Python 3.11
+``[Base]ExceptionGroup`` from `pep 654`_ via the backported
+`exceptiongroup`_ package and some final fixes to the debug mode
+subsystem.
+
+This port ended up driving some (hopefully) final fixes to our debugger
+subsystem including the solution to all lingering stdstreams locking
+race-conditions and deadlock scenarios. This includes extending the
+debugger tests suite as well as cancellation and ``asyncio`` mode cases.
+Some of the notable details:
+
+- always reverting to the ``trio`` SIGINT handler when leaving debug
+  mode.
+- bypassing child attempts to acquire the debug lock when detected
+  to be amdist actor-runtime-cancellation.
+- allowing the root actor to cancel local but IPC-stale subactor
+  requests-tasks for the debug lock when in a "no IPC peers" state.
+
+Further we refined our ``ActorNursery`` semantics to be more similar to
+``trio`` in the sense that parent task errors are always packed into the
+actor-nursery emitted exception group and adjusted all tests and
+examples accordingly.
+
+.. _pep 654: https://peps.python.org/pep-0654/#handling-exception-groups
+.. _exceptiongroup: https://github.com/python-trio/exceptiongroup

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'trio >= 0.22',
         'async_generator',
         'trio_typing',
+        'exceptiongroup',
 
         # tooling
         'tricycle',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         # trio related
         # proper range spec:
         # https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/#id5
-        'trio >= 0.20, < 0.22',
+        'trio >= 0.22',
         'async_generator',
         'trio_typing',
 

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -8,6 +8,7 @@ import builtins
 import itertools
 import importlib
 
+from exceptiongroup import BaseExceptionGroup
 import pytest
 import trio
 import tractor
@@ -409,11 +410,12 @@ def test_trio_error_cancels_intertask_chan(arb_addr):
             # should trigger remote actor error
             await portal.result()
 
-    with pytest.raises(RemoteActorError) as excinfo:
+    with pytest.raises(BaseExceptionGroup) as excinfo:
         trio.run(main)
 
-    # ensure boxed error is correct
-    assert excinfo.value.type == Exception
+    # ensure boxed errors
+    for exc in excinfo.value.exceptions:
+        assert exc.type == Exception
 
 
 def test_trio_closes_early_and_channel_exits(arb_addr):
@@ -442,11 +444,12 @@ def test_aio_errors_and_channel_propagates_and_closes(arb_addr):
             # should trigger remote actor error
             await portal.result()
 
-    with pytest.raises(RemoteActorError) as excinfo:
+    with pytest.raises(BaseExceptionGroup) as excinfo:
         trio.run(main)
 
-    # ensure boxed error is correct
-    assert excinfo.value.type == Exception
+    # ensure boxed errors
+    for exc in excinfo.value.exceptions:
+        assert exc.type == Exception
 
 
 @tractor.context

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -11,15 +11,15 @@ from conftest import tractor_test
 
 
 @pytest.mark.trio
-async def test_no_arbitter():
+async def test_no_runtime():
     """An arbitter must be established before any nurseries
     can be created.
 
     (In other words ``tractor.open_root_actor()`` must be engaged at
     some point?)
     """
-    with pytest.raises(RuntimeError):
-        with tractor.open_nursery():
+    with pytest.raises(RuntimeError) :
+        async with tractor.find_actor('doggy'):
             pass
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -62,7 +62,10 @@ async def test_lifetime_stack_wipes_tmpfile(
                         )
                     ).result()
 
-    except tractor.RemoteActorError:
+    except (
+        tractor.RemoteActorError,
+        tractor.BaseExceptionGroup,
+    ):
         pass
 
     # tmp file should have been wiped by

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -18,7 +18,7 @@
 tractor: structured concurrent "actors".
 
 """
-from trio import MultiError
+from exceptiongroup import BaseExceptionGroup
 
 from ._clustering import open_actor_cluster
 from ._ipc import Channel
@@ -62,7 +62,7 @@ __all__ = [
     'ContextCancelled',
     'ModuleNotExposed',
     'MsgStream',
-    'MultiError',
+    'BaseExceptionGroup',
     'Portal',
     'ReceiveMsgStream',
     'RemoteActorError',

--- a/tractor/_debug.py
+++ b/tractor/_debug.py
@@ -25,6 +25,7 @@ import signal
 from functools import partial
 from contextlib import asynccontextmanager as acm
 from typing import (
+    Any,
     Optional,
     Callable,
     AsyncIterator,
@@ -75,7 +76,9 @@ class Lock:
     # placeholder for function to set a ``trio.Event`` on debugger exit
     # pdb_release_hook: Optional[Callable] = None
 
-    _trio_handler: Callable | None = None
+    _trio_handler: Callable[
+        [int, Optional[FrameType]], Any
+    ] | int | None = None
 
     # actor-wide variable pointing to current task name using debugger
     local_task_in_debug: str | None = None

--- a/tractor/_debug.py
+++ b/tractor/_debug.py
@@ -365,7 +365,7 @@ async def wait_for_parent_stdin_hijack(
 
                 ) as (ctx, val):
 
-                    log.pdb('locked context')
+                    log.debug('locked context')
                     assert val == 'Locked'
 
                     async with ctx.open_stream() as stream:
@@ -384,15 +384,14 @@ async def wait_for_parent_stdin_hijack(
                         # sync with callee termination
                         assert await ctx.result() == "pdb_unlock_complete"
 
-                log.pdb('unlocked context')
+                log.debug('exitting child side locking task context')
 
         except ContextCancelled:
             log.warning('Root actor cancelled debug lock')
 
         finally:
-            log.pdb(f"Exiting debugger for actor {actor_uid}")
             Lock.local_task_in_debug = None
-            log.pdb(f"Child {actor_uid} released parent stdio lock")
+            log.debug(f'Exiting debugger from child')
 
 
 def mk_mpdb() -> tuple[MultiActorPdb, Callable]:

--- a/tractor/_exceptions.py
+++ b/tractor/_exceptions.py
@@ -121,10 +121,12 @@ def unpack_error(
     err_type=RemoteActorError
 
 ) -> Exception:
-    """Unpack an 'error' message from the wire
+    '''
+    Unpack an 'error' message from the wire
     into a local ``RemoteActorError``.
 
-    """
+    '''
+    __tracebackhide__ = True
     error = msg['error']
 
     tb_str = error.get('tb_str', '')

--- a/tractor/_exceptions.py
+++ b/tractor/_exceptions.py
@@ -27,6 +27,7 @@ import importlib
 import builtins
 import traceback
 
+import exceptiongroup as eg
 import trio
 
 
@@ -51,9 +52,6 @@ class RemoteActorError(Exception):
 
         self.type = suberror_type
         self.msgdata = msgdata
-
-    # TODO: a trio.MultiError.catch like context manager
-    # for catching underlying remote errors of a particular type
 
 
 class InternalActorError(RemoteActorError):
@@ -139,7 +137,12 @@ def unpack_error(
         suberror_type = trio.Cancelled
 
     else:  # try to lookup a suitable local error type
-        for ns in [builtins, _this_mod, trio]:
+        for ns in [
+            builtins,
+            _this_mod,
+            eg,
+            trio,
+        ]:
             try:
                 suberror_type = getattr(ns, type_name)
                 break
@@ -158,12 +161,15 @@ def unpack_error(
 
 
 def is_multi_cancelled(exc: BaseException) -> bool:
-    """Predicate to determine if a ``trio.MultiError`` contains only
-    ``trio.Cancelled`` sub-exceptions (and is likely the result of
+    '''
+    Predicate to determine if a possible ``eg.BaseExceptionGroup`` contains
+    only ``trio.Cancelled`` sub-exceptions (and is likely the result of
     cancelling a collection of subtasks.
 
-    """
-    return not trio.MultiError.filter(
-        lambda exc: exc if not isinstance(exc, trio.Cancelled) else None,
-        exc,
-    )
+    '''
+    if isinstance(exc, eg.BaseExceptionGroup):
+        return exc.subgroup(
+            lambda exc: isinstance(exc, trio.Cancelled)
+        ) is not None
+
+    return False

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -52,17 +52,17 @@ log = get_logger(__name__)
 
 
 def _unwrap_msg(
-
     msg: dict[str, Any],
     channel: Channel
 
 ) -> Any:
+    __tracebackhide__ = True
     try:
         return msg['return']
     except KeyError:
         # internal error should never get here
         assert msg.get('cid'), "Received internal error at portal?"
-        raise unpack_error(msg, channel)
+        raise unpack_error(msg, channel) from None
 
 
 class MessagingError(Exception):
@@ -136,6 +136,7 @@ class Portal:
         Return the result(s) from the remote actor's "main" task.
 
         '''
+        # __tracebackhide__ = True
         # Check for non-rpc errors slapped on the
         # channel for which we always raise
         exc = self.channel._exc

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -460,7 +460,6 @@ class Portal:
             # sure it's worth being pedantic:
             # Exception,
             # trio.Cancelled,
-            # trio.MultiError,
             # KeyboardInterrupt,
 
         ) as err:

--- a/tractor/_root.py
+++ b/tractor/_root.py
@@ -29,6 +29,8 @@ from typing import (
 import typing
 import warnings
 
+
+from exceptiongroup import BaseExceptionGroup
 import trio
 
 from ._runtime import Actor, Arbiter, async_main
@@ -205,7 +207,10 @@ async def open_root_actor(
             try:
                 yield actor
 
-            except (Exception, trio.MultiError) as err:
+            except (
+                Exception,
+                BaseExceptionGroup,
+            ) as err:
 
                 entered = await _debug._maybe_enter_pm(err)
 

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -140,6 +140,7 @@ async def exhaust_portal(
     If the main task is an async generator do our best to consume
     what's left of it.
     '''
+    __tracebackhide__ = True
     try:
         log.debug(f"Waiting on final result from {actor.uid}")
 

--- a/tractor/_state.py
+++ b/tractor/_state.py
@@ -22,7 +22,6 @@ from typing import (
     Optional,
     Any,
 )
-from collections.abc import Mapping
 
 import trio
 
@@ -44,12 +43,6 @@ def current_actor(err_on_no_runtime: bool = True) -> 'Actor':  # type: ignore # 
         raise NoRuntime("No local actor has been initialized yet")
 
     return _current_actor
-
-
-_conc_name_getters = {
-    'task': trio.lowlevel.current_task,
-    'actor': current_actor
-}
 
 
 def is_main_process() -> bool:

--- a/tractor/_state.py
+++ b/tractor/_state.py
@@ -52,24 +52,6 @@ _conc_name_getters = {
 }
 
 
-class ActorContextInfo(Mapping):
-    "Dyanmic lookup for local actor and task names"
-    _context_keys = ('task', 'actor')
-
-    def __len__(self):
-        return len(self._context_keys)
-
-    def __iter__(self):
-        return iter(self._context_keys)
-
-    def __getitem__(self, key: str) -> str:
-        try:
-            return _conc_name_getters[key]().name  # type: ignore
-        except RuntimeError:
-            # no local actor/task context initialized yet
-            return f'no {key} context'
-
-
 def is_main_process() -> bool:
     """Bool determining if this actor is running in the top-most process.
     """

--- a/tractor/_supervise.py
+++ b/tractor/_supervise.py
@@ -301,7 +301,7 @@ async def _open_and_supervise_one_cancels_all_nursery(
 ) -> typing.AsyncGenerator[ActorNursery, None]:
 
     # the collection of errors retreived from spawned sub-actors
-    errors: dict[tuple[str, str], Exception] = {}
+    errors: dict[tuple[str, str], BaseException] = {}
 
     # This is the outermost level "deamon actor" nursery. It is awaited
     # **after** the below inner "run in actor nursery". This allows for
@@ -347,7 +347,6 @@ async def _open_and_supervise_one_cancels_all_nursery(
                     anursery._join_procs.set()
 
                 except BaseException as err:
-
                     # If we error in the root but the debugger is
                     # engaged we don't want to prematurely kill (and
                     # thus clobber access to) the local tty since it
@@ -383,7 +382,7 @@ async def _open_and_supervise_one_cancels_all_nursery(
                             else:
                                 log.exception(
                                     f"Nursery for {current_actor().uid} "
-                                    f"errored with {err}, ")
+                                    f"errored with")
 
                             # cancel all subactors
                             await anursery.cancel()
@@ -410,7 +409,8 @@ async def _open_and_supervise_one_cancels_all_nursery(
             BaseExceptionGroup,
             trio.Cancelled
 
-        ) as err:
+        ) as err:  # noqa
+            errors[actor.uid] = err
 
             # XXX: yet another guard before allowing the cancel
             # sequence in case a (single) child is in debug.

--- a/tractor/_supervise.py
+++ b/tractor/_supervise.py
@@ -83,7 +83,7 @@ class ActorNursery:
         actor: Actor,
         ria_nursery: trio.Nursery,
         da_nursery: trio.Nursery,
-        errors: dict[tuple[str, str], Exception],
+        errors: dict[tuple[str, str], BaseException],
     ) -> None:
         # self.supervisor = supervisor  # TODO
         self._actor: Actor = actor


### PR DESCRIPTION
Attempting to get the new `py3.11` driven [exception group](https://peps.python.org/pep-0654/#exceptiongroup-and-baseexceptiongroup) backport support in. See [pep 654](https://peps.python.org/pep-0654/#handling-exception-groups) for dirty deats.


Pertains to fixing #332 and appears to have caused a bunch of test hangs particularly in the debugger suite (which I've manually verified) which need some investigation.

**UPDATE** tests now fixed with the landing of #337 🏄🏼 