### PR TITLE
Pin pre-0.22 bc exception groups break everything

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,9 @@ setup(
     install_requires=[
 
         # trio related
-        'trio >= 0.20',
+        # proper range spec:
+        # https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/#id5
+        'trio >= 0.20, < 0.22',
         'async_generator',
         'trio_typing',
 


### PR DESCRIPTION
As per the ongoing work in #333 we are currently broken on latest `trio` due to the new `ExceptionGroup` changes / support in the stdlib and we need to avoid using `0.22` until that work is complete.