### PR TITLE
Callable key maybe open context

### DIFF
--- a/nooz/336.trivial.rst
+++ b/nooz/336.trivial.rst
@@ -1,0 +1,4 @@
+Add ``key: Callable[..., Hashable]`` support to ``.trionics.maybe_open_context()``
+
+Gives users finer grained control over cache hit behaviour using
+a callable which receives the input ``kwargs: dict``.

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -35,6 +35,7 @@ import warnings
 import trio
 from async_generator import asynccontextmanager
 
+from .trionics import maybe_open_nursery
 from ._state import current_actor
 from ._ipc import Channel
 from .log import get_logger
@@ -48,25 +49,6 @@ from ._streaming import Context, ReceiveMsgStream
 
 
 log = get_logger(__name__)
-
-
-@asynccontextmanager
-async def maybe_open_nursery(
-    nursery: trio.Nursery = None,
-    shield: bool = False,
-) -> AsyncGenerator[trio.Nursery, Any]:
-    '''
-    Create a new nursery if None provided.
-
-    Blocks on exit as expected if no input nursery is provided.
-
-    '''
-    if nursery is not None:
-        yield nursery
-    else:
-        async with trio.open_nursery() as nursery:
-            nursery.cancel_scope.shield = shield
-            yield nursery
 
 
 def _unwrap_msg(

--- a/tractor/trionics/__init__.py
+++ b/tractor/trionics/__init__.py
@@ -21,6 +21,7 @@ Sugary patterns for trio + tractor designs.
 from ._mngrs import (
     gather_contexts,
     maybe_open_context,
+    maybe_open_nursery,
 )
 from ._broadcast import (
     broadcast_receiver,
@@ -35,4 +36,5 @@ __all__ = [
     'BroadcastReceiver',
     'Lagged',
     'maybe_open_context',
+    'maybe_open_nursery',
 ]


### PR DESCRIPTION
Replacement for #329 since we can't easily do the whole "one nursery per context def" style..

Adds a `key: Callable[..., Hashable]` support and moves `maybe_open_nursery()` into this `trionics._mngrs.py` module which allows for more dynamic control over hashing logic.