### PR TITLE
Debug lock blocking

### DIFF
--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -203,24 +203,25 @@ def test_context_spawns_aio_task_that_errors(
     '''
     async def main():
 
-        async with tractor.open_nursery() as n:
-            p = await n.start_actor(
-                'aio_daemon',
-                enable_modules=[__name__],
-                infect_asyncio=True,
-                # debug_mode=True,
-                loglevel='cancel',
-            )
-            async with p.open_context(
-                trio_ctx,
-            ) as (ctx, first):
+        with trio.fail_after(2):
+            async with tractor.open_nursery() as n:
+                p = await n.start_actor(
+                    'aio_daemon',
+                    enable_modules=[__name__],
+                    infect_asyncio=True,
+                    # debug_mode=True,
+                    loglevel='cancel',
+                )
+                async with p.open_context(
+                    trio_ctx,
+                ) as (ctx, first):
 
-                assert first == 'start'
+                    assert first == 'start'
 
-                if parent_cancels:
-                    await p.cancel_actor()
+                    if parent_cancels:
+                        await p.cancel_actor()
 
-                await trio.sleep_forever()
+                    await trio.sleep_forever()
 
     with pytest.raises(RemoteActorError) as excinfo:
         trio.run(main)

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -170,11 +170,11 @@ async def trio_ctx(
     # message.
     with trio.fail_after(2):
         async with (
+            trio.open_nursery() as n,
+
             tractor.to_asyncio.open_channel_from(
                 sleep_and_err,
             ) as (first, chan),
-
-            trio.open_nursery() as n,
         ):
 
             assert first == 'start'

--- a/tractor/_runtime.py
+++ b/tractor/_runtime.py
@@ -234,6 +234,9 @@ async def _invoke(
                         f'{ctx.chan.uid}'
                     )
 
+                if ctx._cancel_msg:
+                    msg += f' with msg:\n{ctx._cancel_msg}'
+
                 # task-contex was cancelled so relay to the cancel to caller
                 raise ContextCancelled(
                     msg,
@@ -275,8 +278,16 @@ async def _invoke(
             # if not is_multi_cancelled(err) and (
 
             entered_debug: bool = False
-            if not isinstance(err, ContextCancelled) or (
-                isinstance(err, ContextCancelled) and ctx._cancel_called
+            if (
+                not isinstance(err, ContextCancelled)
+                or (
+                    isinstance(err, ContextCancelled)
+                    and ctx._cancel_called
+
+                    # if the root blocks the debugger lock request from a child
+                    # we will get a remote-cancelled condition.
+                    and ctx._enter_debugger_on_cancel
+                )
             ):
                 # XXX: is there any case where we'll want to debug IPC
                 # disconnects as a default?
@@ -286,7 +297,6 @@ async def _invoke(
                 # recovery logic - the only case is some kind of strange bug
                 # in our transport layer itself? Going to keep this
                 # open ended for now.
-
                 entered_debug = await _debug._maybe_enter_pm(err)
 
                 if not entered_debug:
@@ -701,6 +711,34 @@ class Actor:
                 # for (uid, cid) in self._contexts.copy():
                 #     if chan.uid == uid:
                 #         self._contexts.pop((uid, cid))
+
+                # NOTE: block this actor from acquiring the
+                # debugger-TTY-lock since we have no way to know if we
+                # cancelled it and further there is no way to ensure the
+                # lock will be released if acquired due to having no
+                # more active IPC channels.
+                if (
+                    _state.is_root_process()
+                ):
+                    pdb_lock = _debug.Lock
+                    log.cancel(
+                        f'{uid} is now blocked from debugger lock'
+                    )
+                    log.runtime(f"{uid} blocked from pdb locking")
+                    pdb_lock._blocked.add(uid)
+
+                    # if a now stale local task has the TTY lock still
+                    # we cancel it to allow servicing other requests for
+                    # the lock.
+                    if (
+                        pdb_lock._root_local_task_cs_in_debug
+                        and not pdb_lock._root_local_task_cs_in_debug.cancel_called
+                    ):
+                        log.warning(
+                            f'STALE DEBUG LOCK DETECTED FOR {uid}'
+                        )
+                        # TODO: figure out why this breaks tests..
+                        # pdb_lock._root_local_task_cs_in_debug.cancel()
 
             log.runtime(f"Peers is {self._peers}")
 

--- a/tractor/_streaming.py
+++ b/tractor/_streaming.py
@@ -371,6 +371,8 @@ class Context:
 
     # status flags
     _cancel_called: bool = False
+    _cancel_msg: Optional[str] = None
+    _trigger_debugger_on_cancel: bool = True
     _started_called: bool = False
     _started_received: bool = False
     _stream_opened: bool = False
@@ -452,7 +454,11 @@ class Context:
                 if not self._scope_nursery._closed:  # type: ignore
                     self._scope_nursery.start_soon(raiser)
 
-    async def cancel(self) -> None:
+    async def cancel(
+        self,
+        msg: Optional[str] = None,
+
+    ) -> None:
         '''
         Cancel this inter-actor-task context.
 
@@ -461,6 +467,8 @@ class Context:
 
         '''
         side = 'caller' if self._portal else 'callee'
+        if msg:
+            assert side == 'callee', 'Only callee side can provide cancel msg'
 
         log.cancel(f'Cancelling {side} side of context to {self.chan.uid}')
 
@@ -497,8 +505,10 @@ class Context:
                     log.cancel(
                         "Timed out on cancelling remote task "
                         f"{cid} for {self._portal.channel.uid}")
+
+        # callee side remote task
         else:
-            # callee side remote task
+            self._cancel_msg = msg
 
             # TODO: should we have an explicit cancel message
             # or is relaying the local `trio.Cancelled` as an

--- a/tractor/_streaming.py
+++ b/tractor/_streaming.py
@@ -372,7 +372,7 @@ class Context:
     # status flags
     _cancel_called: bool = False
     _cancel_msg: Optional[str] = None
-    _trigger_debugger_on_cancel: bool = True
+    _enter_debugger_on_cancel: bool = True
     _started_called: bool = False
     _started_received: bool = False
     _stream_opened: bool = False

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -466,11 +466,11 @@ async def open_channel_from(
         ):
             # sync to a "started()"-like first delivered value from the
             # ``asyncio`` task.
-            first = await chan.receive()
-
-            # deliver stream handle upward
             try:
                 with chan._trio_cs:
+                    first = await chan.receive()
+
+                    # deliver stream handle upward
                     yield first, chan
             finally:
                 chan._trio_exited = True
@@ -491,16 +491,18 @@ def run_as_asyncio_guest(
     SC semantics.
 
     '''
-    # Uh, oh. :o
+    # Uh, oh.
+    #
+    # :o
 
     # It looks like your event loop has caught a case of the ``trio``s.
 
     # :()
 
-    # Don't worry, we've heard you'll barely notice. You might hallucinate
-    # a few more propagating errors and feel like your digestion has
-    # slowed but if anything get's too bad your parents will know about
-    # it.
+    # Don't worry, we've heard you'll barely notice. You might
+    # hallucinate a few more propagating errors and feel like your
+    # digestion has slowed but if anything get's too bad your parents
+    # will know about it.
 
     # :)
 


### PR DESCRIPTION
Pulled out from #333.

Provides a (decent) solution to the problem of a sub-actor (of the root) who loses IPC connectivity but still tries to acquire the stdstreams / TTY lock. This failure mode can result in a deadlock where the root thinks the child is in debug while the child is waiting to be cancelled and because of our debug mode `SIGINT` override handler, the root and child never tear down on `ctl-c` from the user..

---
This patch solves that by taking a simple approach: whenever the root actor detects that some peer (who presumably is some child-ish) has no more working IPC (channel) connections, will stick the sub's `Actor.uid` on a new `._debug.Lock._blocked` list such that the actor is furthermore blocked from acquiring the lock and will be rejected from such with a `ContextCancelled`.

---
Additionally included here is some test fixes which accommodate this change, mainly some of the debugger tests terminating earlier then previous due to the block list preventing recurrent locks from a nested child who's parent has already been cancelled and thus IPC disconnected.

Also, is a couple tweaks to the `asyncio` test suite discovered in the #333 tinkerings.