### PR TITLE
Harden cluster tests

### DIFF
--- a/nooz/344.bugfix.rst
+++ b/nooz/344.bugfix.rst
@@ -1,0 +1,11 @@
+Always ``list``-cast the ``mngrs`` input to
+``.trionics.gather_contexts()`` and ensure its size otherwise raise
+a ``ValueError``.
+
+Turns out that trying to pass an inline-style generator comprehension
+doesn't seem to work inside the ``async with`` expression? Further, in
+such a case we can get a hang waiting on the all-entered event
+completion when the internal mngrs iteration is a noop. Instead we
+always greedily check a size and error on empty input; the lazy
+iteration of a generator input is not beneficial anyway since we're
+entering all manager instances in concurrent tasks.

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,5 +1,6 @@
 import itertools
 
+import pytest
 import trio
 import tractor
 from tractor import open_actor_cluster
@@ -11,26 +12,72 @@ from conftest import tractor_test
 MESSAGE = 'tractoring at full speed'
 
 
+def test_empty_mngrs_input_raises() -> None:
+
+    async def main():
+        with trio.fail_after(1):
+            async with (
+                open_actor_cluster(
+                    modules=[__name__],
+
+                    # NOTE: ensure we can passthrough runtime opts
+                    loglevel='info',
+                    # debug_mode=True,
+
+                ) as portals,
+
+                gather_contexts(
+                    # NOTE: it's the use of inline-generator syntax
+                    # here that causes the empty input.
+                    mngrs=(
+                        p.open_context(worker) for p in portals.values()
+                    ),
+                ),
+            ):
+                assert 0
+
+    with pytest.raises(ValueError):
+        trio.run(main)
+
+
 @tractor.context
-async def worker(ctx: tractor.Context) -> None:
+async def worker(
+    ctx: tractor.Context,
+
+) -> None:
+
     await ctx.started()
-    async with ctx.open_stream(backpressure=True) as stream:
+
+    async with ctx.open_stream(
+        backpressure=True,
+    ) as stream:
+
+        # TODO: this with the below assert causes a hang bug?
+        # with trio.move_on_after(1):
+
         async for msg in stream:
             # do something with msg
             print(msg)
             assert msg == MESSAGE
 
+        # TODO: does this ever cause a hang
+        # assert 0
+
 
 @tractor_test
 async def test_streaming_to_actor_cluster() -> None:
+
     async with (
         open_actor_cluster(modules=[__name__]) as portals,
+
         gather_contexts(
             mngrs=[p.open_context(worker) for p in portals.values()],
         ) as contexts,
+
         gather_contexts(
             mngrs=[ctx[0].open_stream() for ctx in contexts],
         ) as streams,
+
     ):
         with trio.move_on_after(1):
             for stream in itertools.cycle(streams):

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -634,18 +634,23 @@ def test_multi_daemon_subactors(
     # expect another breakpoint actor entry
     child.sendline('c')
     child.expect(r"\(Pdb\+\+\)")
-    assert_before(child, [bp_forever_msg])
 
-    if ctlc:
-        do_ctlc(child)
+    try:
+        assert_before(child, [bp_forever_msg])
+    except AssertionError:
+        assert_before(child, [name_error_msg])
 
-    # should crash with the 2nd name error (simulates
-    # a retry) and then the root eventually (boxed) errors
-    # after 1 or more further bp actor entries.
+    else:
+        if ctlc:
+            do_ctlc(child)
 
-    child.sendline('c')
-    child.expect(r"\(Pdb\+\+\)")
-    assert_before(child, [name_error_msg])
+        # should crash with the 2nd name error (simulates
+        # a retry) and then the root eventually (boxed) errors
+        # after 1 or more further bp actor entries.
+
+        child.sendline('c')
+        child.expect(r"\(Pdb\+\+\)")
+        assert_before(child, [name_error_msg])
 
     # wait for final error in root
     # where it crashs with boxed error
@@ -660,10 +665,6 @@ def test_multi_daemon_subactors(
         except AssertionError:
             break
 
-    # child.sendline('c')
-    # assert_before(
-
-    # child.sendline('c')
     assert_before(
         child,
         [

--- a/tractor/_clustering.py
+++ b/tractor/_clustering.py
@@ -32,9 +32,12 @@ import tractor
 async def open_actor_cluster(
     modules: list[str],
     count: int = cpu_count(),
-    names: Optional[list[str]] = None,
-    start_method: Optional[str] = None,
+    names: list[str] | None = None,
     hard_kill: bool = False,
+
+    # passed through verbatim to ``open_root_actor()``
+    **runtime_kwargs,
+
 ) -> AsyncGenerator[
     dict[str, tractor.Portal],
     None,
@@ -49,7 +52,9 @@ async def open_actor_cluster(
         raise ValueError(
             'Number of names is {len(names)} but count it {count}')
 
-    async with tractor.open_nursery(start_method=start_method) as an:
+    async with tractor.open_nursery(
+        **runtime_kwargs,
+    ) as an:
         async with trio.open_nursery() as n:
             uid = tractor.current_actor().uid
 

--- a/tractor/_discovery.py
+++ b/tractor/_discovery.py
@@ -108,7 +108,7 @@ async def query_actor(
 @acm
 async def find_actor(
     name: str,
-    arbiter_sockaddr: tuple[str, int] = None
+    arbiter_sockaddr: tuple[str, int] | None = None
 
 ) -> AsyncGenerator[Optional[Portal], None]:
     '''
@@ -134,7 +134,7 @@ async def find_actor(
 @acm
 async def wait_for_actor(
     name: str,
-    arbiter_sockaddr: tuple[str, int] = None
+    arbiter_sockaddr: tuple[str, int] | None = None
 ) -> AsyncGenerator[Portal, None]:
     """Wait on an actor to register with the arbiter.
 

--- a/tractor/_entry.py
+++ b/tractor/_entry.py
@@ -51,7 +51,7 @@ def _mp_main(
     accept_addr: tuple[str, int],
     forkserver_info: tuple[Any, Any, Any, Any, Any],
     start_method: SpawnMethodKey,
-    parent_addr: tuple[str, int] = None,
+    parent_addr: tuple[str, int] | None = None,
     infect_asyncio: bool = False,
 
 ) -> None:
@@ -98,7 +98,7 @@ def _trio_main(
 
     actor: Actor,  # type: ignore
     *,
-    parent_addr: tuple[str, int] = None,
+    parent_addr: tuple[str, int] | None = None,
     infect_asyncio: bool = False,
 
 ) -> None:

--- a/tractor/_ipc.py
+++ b/tractor/_ipc.py
@@ -341,7 +341,7 @@ class Channel:
 
     async def connect(
         self,
-        destaddr: tuple[Any, ...] = None,
+        destaddr: tuple[Any, ...] | None = None,
         **kwargs
 
     ) -> MsgTransport:

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -186,7 +186,7 @@ class Portal:
 
     async def cancel_actor(
         self,
-        timeout: float = None,
+        timeout: float | None = None,
 
     ) -> bool:
         '''

--- a/tractor/_portal.py
+++ b/tractor/_portal.py
@@ -536,7 +536,10 @@ class Portal:
             await maybe_wait_for_debugger()
 
             # remove the context from runtime tracking
-            self.actor._contexts.pop((self.channel.uid, ctx.cid))
+            self.actor._contexts.pop(
+                (self.channel.uid, ctx.cid),
+                None,
+            )
 
 
 @dataclass

--- a/tractor/_supervise.py
+++ b/tractor/_supervise.py
@@ -111,11 +111,11 @@ class ActorNursery:
         name: str,
         *,
         bind_addr: tuple[str, int] = _default_bind_addr,
-        rpc_module_paths: list[str] = None,
-        enable_modules: list[str] = None,
-        loglevel: str = None,  # set log level per subactor
-        nursery: trio.Nursery = None,
-        debug_mode: Optional[bool] = None,
+        rpc_module_paths: list[str] | None = None,
+        enable_modules: list[str] | None = None,
+        loglevel: str | None = None,  # set log level per subactor
+        nursery: trio.Nursery | None = None,
+        debug_mode: Optional[bool] | None = None,
         infect_asyncio: bool = False,
     ) -> Portal:
         '''
@@ -182,9 +182,9 @@ class ActorNursery:
 
         name: Optional[str] = None,
         bind_addr: tuple[str, int] = _default_bind_addr,
-        rpc_module_paths: Optional[list[str]] = None,
-        enable_modules: list[str] = None,
-        loglevel: str = None,  # set log level per subactor
+        rpc_module_paths: list[str] | None = None,
+        enable_modules: list[str] | None = None,
+        loglevel: str | None = None,  # set log level per subactor
         infect_asyncio: bool = False,
 
         **kwargs,  # explicit args to ``fn``

--- a/tractor/experimental/_pubsub.py
+++ b/tractor/experimental/_pubsub.py
@@ -48,7 +48,7 @@ log = get_logger('messaging')
 async def fan_out_to_ctxs(
     pub_async_gen_func: typing.Callable,  # it's an async gen ... gd mypy
     topics2ctxs: dict[str, list],
-    packetizer: typing.Callable = None,
+    packetizer: typing.Callable | None = None,
 ) -> None:
     '''
     Request and fan out quotes to each subscribed actor channel.
@@ -144,7 +144,7 @@ _pubtask2lock: dict[str, trio.StrictFIFOLock] = {}
 
 
 def pub(
-    wrapped: typing.Callable = None,
+    wrapped: typing.Callable | None = None,
     *,
     tasks: set[str] = set(),
 ):
@@ -249,8 +249,8 @@ def pub(
             topics: set[str],
             *args,
             # *,
-            task_name: str = None,  # default: only one task allocated
-            packetizer: Callable = None,
+            task_name: str | None = None,  # default: only one task allocated
+            packetizer: Callable | None = None,
             **kwargs,
         ):
             if task_name is None:

--- a/tractor/log.py
+++ b/tractor/log.py
@@ -172,7 +172,7 @@ class ActorContextInfo(Mapping):
 
 def get_logger(
 
-    name: str = None,
+    name: str | None = None,
     _root_name: str = _proj_name,
 
 ) -> StackLevelAdapter:
@@ -207,7 +207,7 @@ def get_logger(
 
 
 def get_console_log(
-    level: str = None,
+    level: str | None = None,
     **kwargs,
 ) -> logging.LoggerAdapter:
     '''Get the package logger and enable a handler which writes to stderr.

--- a/tractor/trionics/_mngrs.py
+++ b/tractor/trionics/_mngrs.py
@@ -47,7 +47,7 @@ T = TypeVar("T")
 
 @acm
 async def maybe_open_nursery(
-    nursery: trio.Nursery = None,
+    nursery: trio.Nursery | None = None,
     shield: bool = False,
 ) -> AsyncGenerator[trio.Nursery, Any]:
     '''

--- a/tractor/trionics/_mngrs.py
+++ b/tractor/trionics/_mngrs.py
@@ -109,6 +109,17 @@ async def gather_contexts(
     all_entered = trio.Event()
     parent_exit = trio.Event()
 
+    # XXX: ensure greedy sequence of manager instances
+    # since a lazy inline generator doesn't seem to work
+    # with `async with` syntax.
+    mngrs = list(mngrs)
+
+    if not mngrs:
+        raise ValueError(
+            'input mngrs is empty?\n'
+            'Did try to use inline generator syntax?'
+        )
+
     async with trio.open_nursery() as n:
         for mngr in mngrs:
             n.start_soon(


### PR DESCRIPTION
In response to a weird issue discovered by @guilledk where if you pass in a `mngrs=(<generator comprehension>)`, you end up with an empty sequence in the loop inside `trionics.gather_contexts()` and then  a hang due to waiting on the `all_entered: trio.Event` [just after the loop](https://github.com/goodboy/tractor/blob/master/tractor/trionics/_mngrs.py#L123).

This solves the issue by greedly converting the `mngrs` sequence to a list and ensuring its size and otherwise raising a `ValueError`.

---
Further TODO for this to land:
- [x] demonstrate issue through hanging test no commit for the fix yet pushed
  - exact test failure [here in CI run](https://github.com/goodboy/tractor/actions/runs/3671732526/jobs/6207227497#step:6:18) from commit [c606be8](https://github.com/goodboy/tractor/pull/344/commits/c606be8c640d43da260ac1d457a3551150b3d85e)
- [x] push the actual fix ([b5192cc](https://github.com/goodboy/tractor/pull/344/commits/b5192cca8ef32d89ab46ba98d231bb47aa1218a3))
- ~add tests for both the generator and empty list input cases~ there's no real reason for this, and further trying to jam in the logic in a `pytest` parametrization is janky..
- [x] nooz snippet

---
Other additions part of this patch:
- we now passthrough all runtime kwargs to the `open_actor_cluster()` helper such that any kwarg to `open_root_actor()` can be used