### PR TITLE
Don't unset actor global on root teardown

### DIFF
--- a/tractor/_root.py
+++ b/tractor/_root.py
@@ -243,7 +243,6 @@ async def open_root_actor(
                 logger.cancel("Shutting down root actor")
                 await actor.cancel()
     finally:
-        _state._current_actor = None
         logger.runtime("Root actor terminated")
 
 

--- a/tractor/_streaming.py
+++ b/tractor/_streaming.py
@@ -69,7 +69,7 @@ class ReceiveMsgStream(trio.abc.ReceiveChannel):
     '''
     def __init__(
         self,
-        ctx: 'Context',  # typing: ignore # noqa
+        ctx: Context,  # typing: ignore # noqa
         rx_chan: trio.MemoryReceiveChannel,
         _broadcaster: Optional[BroadcastReceiver] = None,
 
@@ -81,6 +81,9 @@ class ReceiveMsgStream(trio.abc.ReceiveChannel):
         # flag to denote end of stream
         self._eoc: bool = False
         self._closed: bool = False
+
+    def ctx(self) -> Context:
+        return self._ctx
 
     # delegate directly to underlying mem channel
     def receive_nowait(self):
@@ -380,7 +383,7 @@ class Context:
     # only set on the callee side
     _scope_nursery: Optional[trio.Nursery] = None
 
-    _backpressure: bool = False
+    _backpressure: bool = True
 
     async def send_yield(self, data: Any) -> None:
 


### PR DESCRIPTION
Originally changed to address in an issue discovered (at least i thought) in dev of https://github.com/pikers/piker/pull/420, but now not so sure we ever needed it and it was some other IPC drops-while-streaming issue?

Anyway, sticking the commit here as a reminder in case the issue exhibits again in `piker`.

Removing this commit seems to fix #345