### PR TITLE
Re-draw `pdbpp` prompt on `SIGINT`

### DIFF
--- a/nooz/349.trivial.rst
+++ b/nooz/349.trivial.rst
@@ -1,0 +1,10 @@
+Always redraw the `pdbpp` prompt on `SIGINT` during REPL use.
+
+There was recent changes todo with Python 3.10 that required us to pin
+to a specific commit in `pdbpp` which have recently been fixed minus
+this last issue with `SIGINT` shielding: not clobbering or not
+showing the `(Pdb++)` prompt on ctlr-c by the user. This repairs all
+that by firstly removing the standard KBI intercepting of the std lib's
+`pdb.Pdb._cmdloop()` as well as ensuring that only the actor with REPL
+control ever reports `SIGINT` handler log msgs and prompt redraws. With
+this we move back to using pypi `pdbpp` release.

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ setup(
         # serialization
         'msgspec',
 
+        # debug mode REPL
+        'pdbpp',
+
         # pip ref docs on these specs:
         # https://pip.pypa.io/en/stable/reference/requirement-specifiers/#examples
         # and pep:
@@ -70,10 +73,6 @@ setup(
         # https://github.com/pdbpp/fancycompleter/issues/37
         'pyreadline3 ; platform_system == "Windows"',
 
-        # 3.10 has an outstanding unreleased issue and `pdbpp` itself
-        #   pins to patched forks of its own dependencies as well..and
-        #   we need a specific patch on master atm.
-        'pdbpp @ git+https://github.com/pdbpp/pdbpp@76c4be5#egg=pdbpp ; python_version > "3.9"',  # noqa: E501
 
     ],
     tests_require=['pytest'],

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -165,17 +165,16 @@ def ctlc(
         # be 3.10+ mega-asap.
         pytest.skip('Py3.9 and `pdbpp` son no bueno..')
 
-    if ci_env:
-        node = request.node
-        markers = node.own_markers
-        for mark in markers:
-            if mark.name == 'has_nested_actors':
-                pytest.skip(
-                    f'Test for {node} uses nested actors and fails in CI\n'
-                    f'The test seems to run fine locally but until we solve'
-                    'this issue this CI test will be xfail:\n'
-                    'https://github.com/goodboy/tractor/issues/320'
-                )
+    node = request.node
+    markers = node.own_markers
+    for mark in markers:
+        if mark.name == 'has_nested_actors':
+            pytest.skip(
+                f'Test {node} has nested actors and fails with Ctrl-C.\n'
+                f'The test can sometimes run fine locally but until'
+                ' we solve' 'this issue this CI test will be xfail:\n'
+                'https://github.com/goodboy/tractor/issues/320'
+            )
 
     if use_ctlc:
         # XXX: disable pygments highlighting for auto-tests

--- a/tractor/_debug.py
+++ b/tractor/_debug.py
@@ -197,7 +197,7 @@ class MultiActorPdb(pdbpp.Pdb):
         self.cmdloop()
 
     @cached_property
-    def shname(self) -> str:
+    def shname(self) -> str | None:
         '''
         Attempt to return the login shell name with a special check for
         the infamous `xonsh` since it seems to have some issues much
@@ -206,11 +206,18 @@ class MultiActorPdb(pdbpp.Pdb):
         '''
         # SUPER HACKY and only really works if `xonsh` is not used
         # before spawning further sub-shells..
-        xonsh_is_login_sh: bool = os.getenv('XONSH_LOGIN', default=False)
-        if xonsh_is_login_sh:
-            return 'xonsh'
+        shpath = os.getenv('SHELL', None)
 
-        return os.path.basename(os.getenv('SHELL'))
+        if shpath:
+            if (
+                os.getenv('XONSH_LOGIN', default=False)
+                or 'xonsh' in shpath
+            ):
+                return 'xonsh'
+
+            return os.path.basename(shpath)
+
+        return None
 
 
 @acm

--- a/tractor/_runtime.py
+++ b/tractor/_runtime.py
@@ -1599,7 +1599,10 @@ async def process_messages(
         # handshake for them (yet) and instead we simply bail out of
         # the message loop and expect the teardown sequence to clean
         # up.
-        log.runtime(f'channel from {chan.uid} closed abruptly:\n{chan}')
+        log.runtime(
+            f'channel from {chan.uid} closed abruptly:\n'
+            f'-> {chan.raddr}\n'
+        )
 
         # transport **was** disconnected
         return True

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -457,6 +457,13 @@ async def trio_proc(
                             await proc.wait()
 
                 if is_root_process():
+                    # TODO: solve the following issue where we need
+                    # to do a similar wait like this but in an
+                    # "intermediary" parent actor that itself isn't
+                    # in debug but has a child that is, and we need
+                    # to hold off on relaying SIGINT until that child
+                    # is complete.
+                    # https://github.com/goodboy/tractor/issues/320
                     await maybe_wait_for_debugger(
                         child_in_debug=_runtime_vars.get(
                             '_debug_mode', False),


### PR DESCRIPTION
Fixes a long running issue todo with ctl-c during `pdbpp` REPL use to ensure that the prompt is always redrawn after log msgs indicating that the SIGINT is being ignored in whatever actor currently owns the TTY lock / is running a REPL.

Also, this resolves the issues (AFAIK) that were preventing us from using the `pypi` version of `pdbpp` as mentioned in https://github.com/goodboy/tractor/issues/323. So we should be able to do a working release again 😂 ?

Probably pertains to:
- #148 (of which most questions i think are answered at this point?)
- https://github.com/goodboy/tractor/issues/113 which is our wish list of features.