### PR TITLE
`taskman`: an initial prototype for a `trio.Nursery`-like per-task-scope-manager (maybe via a user defined single-yield-generator function?) 😎 

### DIFF
--- a/tractor/hilevel/__init__.py
+++ b/tractor/hilevel/__init__.py
@@ -1,0 +1,26 @@
+# tractor: structured concurrent "actors".
+# Copyright 2024-eternity Tyler Goodlet.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+'''
+High level design patterns, APIs and runtime extensions built on top
+of the `tractor` runtime core.
+
+'''
+from ._service import (
+    open_service_mngr as open_service_mngr,
+    get_service_mngr as get_service_mngr,
+    ServiceMngr as ServiceMngr,
+)

--- a/tractor/hilevel/_service.py
+++ b/tractor/hilevel/_service.py
@@ -1,0 +1,132 @@
+# tractor: structured concurrent "actors".
+# Copyright 2024-eternity Tyler Goodlet.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+'''
+Daemon subactor as service(s) management and supervision primitives
+and API.
+
+'''
+from __future__ import annotations
+from contextlib import (
+    # asynccontextmanager as acm,
+    contextmanager as cm,
+)
+from collections import defaultdict
+from typing import (
+    Callable,
+    Any,
+)
+
+import trio
+from trio import TaskStatus
+from tractor import (
+    ActorNursery,
+    current_actor,
+    ContextCancelled,
+    Context,
+    Portal,
+)
+
+from ._util import (
+    log,  # sub-sys logger
+)
+
+
+# TODO: implement a `@singleton` deco-API for wrapping the below
+# factory's impl for general actor-singleton use?
+#
+# -[ ] go through the options peeps on SO did?
+#  * https://stackoverflow.com/questions/6760685/what-is-the-best-way-of-implementing-singleton-in-python
+#  * including @mikenerone's answer
+#   |_https://stackoverflow.com/questions/6760685/what-is-the-best-way-of-implementing-singleton-in-python/39186313#39186313
+#
+# -[ ] put it in `tractor.lowlevel._globals` ?
+#  * fits with our oustanding actor-local/global feat req?
+#   |_ https://github.com/goodboy/tractor/issues/55
+#  * how can it relate to the `Actor.lifetime_stack` that was
+#    silently patched in?
+#   |_ we could implicitly call both of these in the same
+#     spot in the runtime using the lifetime stack?
+#    - `open_singleton_cm().__exit__()`
+#    -`del_singleton()`
+#   |_ gives SC fixtue semantics to sync code oriented around
+#     sub-process lifetime?
+#  * what about with `trio.RunVar`?
+#   |_https://trio.readthedocs.io/en/stable/reference-lowlevel.html#trio.lowlevel.RunVar
+#    - which we'll need for no-GIL cpython (right?) presuming
+#      multiple `trio.run()` calls in process?
+#
+#
+# @singleton
+# async def open_service_mngr(
+#     **init_kwargs,
+# ) -> ServiceMngr:
+#     '''
+#     Note this function body is invoke IFF no existing singleton instance already
+#     exists in this proc's memory.
+
+#     '''
+#     # setup
+#     yield ServiceMngr(**init_kwargs)
+#     # teardown
+
+
+# a deletion API for explicit instance de-allocation?
+# @open_service_mngr.deleter
+# def del_service_mngr() -> None:
+#     mngr = open_service_mngr._singleton[0]
+#     open_service_mngr._singleton[0] = None
+#     del mngr
+
+
+
+# TODO: singleton factory API instead of a class API
+@cm
+def open_service_mngr(
+    *,
+    _singleton: list[ServiceMngr|None] = [None],
+    # NOTE; since default values for keyword-args are effectively
+    # module-vars/globals as per the note from,
+    # https://docs.python.org/3/tutorial/controlflow.html#default-argument-values
+    #
+    # > "The default value is evaluated only once. This makes
+    #   a difference when the default is a mutable object such as
+    #   a list, dictionary, or instances of most classes"
+    #
+    **init_kwargs,
+
+) -> ServiceMngr:
+    '''
+    Open a multi-subactor-as-service-daemon tree supervisor.
+
+    The delivered `ServiceMngr` is a singleton instance for each
+    actor-process and is allocated on first open and never
+    de-allocated unless explicitly deleted by al call to
+    `del_service_mngr()`.
+
+    '''
+    mngr: ServiceMngr|None
+    if (mngr := _singleton[0]) is None:
+        log.info('Allocating a new service mngr!')
+        mngr = _singleton[0] = ServiceMngr(**init_kwargs)
+    else:
+        log.info(
+            'Using extant service mngr!\n\n'
+            f'{mngr!r}\n'  # it has a nice `.__repr__()` of services state
+        )
+
+    with mngr:
+        yield mngr

--- a/tractor/trionics/__init__.py
+++ b/tractor/trionics/__init__.py
@@ -21,7 +21,6 @@ Sugary patterns for trio + tractor designs.
 from ._mngrs import (
     gather_contexts as gather_contexts,
     maybe_open_context as maybe_open_context,
-    maybe_open_nursery as maybe_open_nursery,
 )
 from ._broadcast import (
     AsyncReceiver as AsyncReceiver,
@@ -36,4 +35,7 @@ from ._beg import (
 )
 from ._taskc import (
     maybe_raise_from_masking_exc as maybe_raise_from_masking_exc,
+)
+from ._tn import (
+    maybe_open_nursery as maybe_open_nursery,
 )

--- a/tractor/trionics/_broadcast.py
+++ b/tractor/trionics/_broadcast.py
@@ -22,7 +22,7 @@ https://docs.rs/tokio/1.11.0/tokio/sync/broadcast/index.html
 from __future__ import annotations
 from abc import abstractmethod
 from collections import deque
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager as acm
 from functools import partial
 from operator import ne
 from typing import (
@@ -398,7 +398,7 @@ class BroadcastReceiver(ReceiveChannel):
 
             return await self._receive_from_underlying(key, state)
 
-    @asynccontextmanager
+    @acm
     async def subscribe(
         self,
         raise_on_lag: bool = True,

--- a/tractor/trionics/_mngrs.py
+++ b/tractor/trionics/_mngrs.py
@@ -24,7 +24,6 @@ from contextlib import (
     asynccontextmanager as acm,
 )
 import inspect
-from types import ModuleType
 from typing import (
     Any,
     AsyncContextManager,
@@ -34,50 +33,23 @@ from typing import (
     Hashable,
     Sequence,
     TypeVar,
-    TYPE_CHECKING,
 )
 
 import trio
 from tractor.runtime._state import current_actor
 from tractor.log import get_logger
+from ._tn import maybe_open_nursery
 # from ._beg import collapse_eg
 # from ._taskc import (
 #     maybe_raise_from_masking_exc,
 # )
 
 
-if TYPE_CHECKING:
-    from tractor import ActorNursery
-
 
 log = get_logger()
 
 # A regular invariant generic type
 T = TypeVar("T")
-
-
-@acm
-async def maybe_open_nursery(
-    nursery: trio.Nursery|ActorNursery|None = None,
-    shield: bool = False,
-    lib: ModuleType = trio,
-
-    **kwargs,  # proxy thru
-
-) -> AsyncGenerator[trio.Nursery, Any]:
-    '''
-    Create a new nursery if None provided.
-
-    Blocks on exit as expected if no input nursery is provided.
-
-    '''
-    if nursery is not None:
-        yield nursery
-    else:
-        async with lib.open_nursery(**kwargs) as nursery:
-            if lib == trio:
-                nursery.cancel_scope.shield = shield
-            yield nursery
 
 
 async def _enter_and_wait(

--- a/tractor/trionics/_supervisor.py
+++ b/tractor/trionics/_supervisor.py
@@ -136,7 +136,7 @@ class ScopePerTaskNursery(Struct):
         else:
             # NOTE: what do we enforce as a signature for the
             # `@task_scope_manager` here?
-            mngr = sm(nursery=n, scope=cs)
+            mngr = sm(nursery=n)
 
         async def _start_wrapped_in_scope(
             task_status: TaskStatus[
@@ -213,11 +213,9 @@ class ScopePerTaskNursery(Struct):
 # @trio.task_scope_manager
 def add_task_handle_and_crash_handling(
     nursery: Nursery,
-    scope: CancelScope,
 
 ) -> Generator[None, list[Any]]:
 
-    cs: CancelScope = CancelScope()
     task_outcome = TaskOutcome()
 
     # if you need it you can ask trio for the task obj
@@ -226,7 +224,7 @@ def add_task_handle_and_crash_handling(
 
     try:
         # yields back when task is terminated, cancelled, returns?
-        with cs:
+        with CancelScope() as cs:
 
             # the yielded value(s) here are what are returned to the
             # nursery's `.start_soon()` caller B)

--- a/tractor/trionics/_supervisor.py
+++ b/tractor/trionics/_supervisor.py
@@ -1,0 +1,256 @@
+# tractor: structured concurrent "actors".
+# Copyright 2018-eternity Tyler Goodlet.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+'''
+Erlang-style (ish) "one-cancels-one" nursery.
+
+'''
+from __future__ import annotations
+from contextlib import (
+    asynccontextmanager as acm,
+    contextmanager as cm,
+    nullcontext,
+)
+from typing import ContextManager
+
+from outcome import (
+    Outcome,
+    acapture,
+)
+import pdbp
+from msgspec import Struct
+import trio
+from trio._core._run import (
+    Task,
+    CancelScope,
+    Nursery,
+)
+
+class MaybeOutcome(Struct):
+
+    _ready: Event = trio.Event()
+    _outcome: Outcome | None = None
+    _result: Any | None = None
+
+    @property
+    def result(self) -> Any:
+        '''
+        Either Any or None depending on whether the Outcome has compeleted.
+
+        '''
+        if self._outcome is None:
+            raise RuntimeError(
+                # f'Task {task.name} is not complete.\n'
+                f'Outcome is not complete.\n'
+                'wait on `await MaybeOutcome.unwrap()` first!'
+            )
+        return self._result
+
+    def _set_outcome(
+        self,
+        outcome: Outcome,
+    ):
+        self._outcome = outcome
+        self._result = outcome.unwrap()
+        self._ready.set()
+
+    # TODO: maybe a better name like,
+    # - .wait_and_unwrap()
+    # - .wait_unwrap()
+    # - .aunwrap() ?
+    async def unwrap(self) -> Any:
+        if self._ready.is_set():
+            return self._result
+
+        await self._ready.wait()
+
+        out = self._outcome
+        if out is None:
+            raise ValueError(f'{out} is not an outcome!?')
+
+        return self.result
+
+
+class TaskHandle(Struct):
+    task: Task
+    cs: CancelScope
+    exited: Event | None = None
+    _outcome: Outcome | None = None
+
+
+class ScopePerTaskNursery(Struct):
+    _n: Nursery
+    _scopes: dict[
+        Task,
+        tuple[CancelScope, Outcome]
+    ] = {}
+
+    scope_manager: ContextManager | None = None
+
+    async def start_soon(
+        self,
+        async_fn,
+        *args,
+
+        name=None,
+        scope_manager: ContextManager | None = None,
+
+    ) -> tuple[CancelScope, Task]:
+
+        # NOTE: internals of a nursery don't let you know what
+        # the most recently spawned task is by order.. so we'd
+        # have to either change that or do set ops.
+        # pre_start_tasks: set[Task] = n._children.copy()
+        # new_tasks = n._children - pre_start_Tasks
+        # assert len(new_tasks) == 1
+        # task = new_tasks.pop()
+
+        n: Nursery = self._n
+        cs = CancelScope()
+        new_task: Task | None = None
+        to_return: tuple[Any] | None = None
+        maybe_outcome = MaybeOutcome()
+
+        sm = self.scope_manager
+        if sm is None:
+            mngr = nullcontext([cs])
+        else:
+            mngr = sm(
+                nursery=n,
+                scope=cs,
+                maybe_outcome=maybe_outcome,
+            )
+
+        async def _start_wrapped_in_scope(
+            task_status: TaskStatus[
+                tuple[CancelScope, Task]
+            ] = trio.TASK_STATUS_IGNORED,
+
+        ) -> None:
+            nonlocal maybe_outcome
+            nonlocal to_return
+
+            with cs:
+
+                task = trio.lowlevel.current_task()
+                self._scopes[cs] = task
+
+                # TODO: instead we should probably just use
+                # `Outcome.send(mngr)` here no and inside a custom
+                # decorator `@trio.cancel_scope_manager` enforce
+                # that it's a single yield generator?
+                with mngr as to_return:
+
+                    # TODO: relay through whatever the
+                    # started task passes back via `.started()` ?
+                    # seems like that won't work with also returning
+                    # a "task handle"?
+                    task_status.started()
+
+                    # invoke underlying func now that cs is entered.
+                    outcome = await acapture(async_fn, *args)
+
+                    # TODO: instead, mngr.send(outcome) so that we don't
+                    # tie this `.start_soon()` impl to the
+                    # `MaybeOutcome` type? Use `Outcome.send(mngr)`
+                    # right?
+                    maybe_outcome._set_outcome(outcome)
+
+        await n.start(_start_wrapped_in_scope)
+        assert to_return is not None
+
+        # TODO: better way to concat the values delivered by the user
+        # provided `.scope_manager` and the outcome?
+        return tuple([maybe_outcome] + to_return)
+
+
+# TODO: maybe just make this a generator with a single yield that also
+# delivers a value (of some std type) from the yield expression?
+# @trio.cancel_scope_manager
+@cm
+def add_task_handle_and_crash_handling(
+    nursery: Nursery,
+    scope: CancelScope,
+    maybe_outcome: MaybeOutcome,
+
+) -> Generator[None, list[Any]]:
+
+    cs: CancelScope = CancelScope()
+
+    # if you need it you can ask trio for the task obj
+    task: Task = trio.lowlevel.current_task()
+    print(f'Spawning task: {task.name}')
+
+    try:
+        # yields back when task is terminated, cancelled, returns?
+        with cs:
+            # the yielded values here are what are returned to the
+            # nursery's `.start_soon()` caller
+
+            # TODO: actually make this work so that `MaybeOutcome` isn't
+            # tied to the impl of `.start_soon()` on our custom nursery!
+            task_outcome: Outcome = yield [cs]
+
+    except Exception as err:
+        # Adds "crash handling" from `pdbp` by entering
+        # a REPL on std errors.
+        pdbp.xpm()
+        raise
+
+
+@acm
+async def open_nursery(
+    scope_manager = None,
+    **kwargs,
+):
+    async with trio.open_nursery(**kwargs) as nurse:
+        yield ScopePerTaskNursery(
+            nurse,
+            scope_manager=scope_manager,
+        )
+
+
+async def sleep_then_err():
+    await trio.sleep(1)
+    assert 0
+
+
+async def sleep_then_return_val(val: str):
+    await trio.sleep(0.2)
+    return val
+
+
+if __name__ == '__main__':
+
+    async def main():
+        async with open_nursery(
+            scope_manager=add_task_handle_and_crash_handling,
+        ) as sn:
+            for _ in range(3):
+                outcome, cs = await sn.start_soon(trio.sleep_forever)
+
+            # extra task we want to engage in debugger post mortem.
+            err_outcome, *_ = await sn.start_soon(sleep_then_err)
+
+            val: str = 'yoyoyo'
+            val_outcome, cs = await sn.start_soon(sleep_then_return_val, val)
+            res = await val_outcome.unwrap()
+            assert res == val
+            print(f'GOT EXPECTED TASK VALUE: {res}')
+
+            print('WAITING FOR CRASH..')
+
+    trio.run(main)

--- a/tractor/trionics/_tn.py
+++ b/tractor/trionics/_tn.py
@@ -1,0 +1,94 @@
+# tractor: structured concurrent "actors".
+# Copyright 2018-eternity Tyler Goodlet.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+'''
+`trio.Nursery` wrappers which we short-hand refer to as
+`tn`: "task nursery".
+
+(whereas we refer to `tractor.ActorNursery` as the short-hand `an`)
+
+'''
+from __future__ import annotations
+from contextlib import (
+    asynccontextmanager as acm,
+)
+from types import ModuleType
+from typing import (
+    Any,
+    AsyncGenerator,
+    TYPE_CHECKING,
+)
+
+import trio
+from tractor.log import get_logger
+
+# from ._beg import (
+#     collapse_eg,
+# )
+
+if TYPE_CHECKING:
+    from tractor import ActorNursery
+
+log = get_logger(__name__)
+
+
+# ??TODO? is this even a good idea??
+# it's an extra LoC to stack `collapse_eg()` vs.
+# a new/foreign/bad-std-named very thing wrapper..?
+# -[ ] is there a better/simpler name?
+# @acm
+# async def open_loose_tn() -> trio.Nursery:
+#     '''
+#     Implements the equivalent of the old style loose eg raising
+#     task-nursery from `trio<=0.25.0` ,
+
+#     .. code-block:: python
+
+#         async with trio.open_nursery(
+#             strict_exception_groups=False,
+#         ) as tn:
+#             ...
+
+#     '''
+#     async with (
+#         collapse_eg(),
+#         trio.open_nursery() as tn,
+#     ):
+#         yield tn
+
+
+@acm
+async def maybe_open_nursery(
+    nursery: trio.Nursery|ActorNursery|None = None,
+    shield: bool = False,
+    lib: ModuleType = trio,
+    loose: bool = False,
+
+    **kwargs,  # proxy thru
+
+) -> AsyncGenerator[trio.Nursery, Any]:
+    '''
+    Create a new nursery if None provided.
+
+    Blocks on exit as expected if no input nursery is provided.
+
+    '''
+    if nursery is not None:
+        yield nursery
+    else:
+        async with lib.open_nursery(**kwargs) as tn:
+            tn.cancel_scope.shield = shield
+            yield tn


### PR DESCRIPTION
As per some discussion in the `trio` gitter and starting something
toward #22 and supporting our debugger crash mode from within
a `trio`-compat task nursery.


---
### Idea: a `trio.Nursery` API for optionally allowing a user to define a per-task *manager*

But why?

Well if you wanted any of the following (some of which are implemented
in the module script in this patch):

- generally gain access to lower level `trio.Nursery` *"internals"* for any
  per-task oriented purpose.
- some way to wrap your own "task handle" so you could do things like
  waiting on a task to finish and get its result.
- allow hooking into each task's exit/teardown (phase) for the purposes
  of debugging crashes, (unexpected) cancels or just generally tracing
  the `trio` per task control flow.
- enable more granular task supervision strategies like `one_for_one`
  from erlang/elixir and friends.


---
#### ToDo:
- [x] offer a `task_manager` context-manager-as-generator API such
  that the current `TaskOutcome` struct **is not** tied to the
  internals of the `ScopePerTaskNursery.start_soon()` implementation.
  - [x] ideally the `outcome: Outcome = yield (cs, ..)` is delivered to
    the user defined mngr ~~via a `Outcome.send(mngr)` call~~ such that only
    raw `trio` (dependency) internal types are provided to the user for
    wrapping / adjusting.
    - **NOTE:** didn't use `Outcome.send()` bc it would send the underlying
      value, not the outcome instance; not sure if that's best?

- [ ] **way better naming** since most of this was whipped up on the
  first try and getting good names is probably going to be tricky :joy:
  - [x] `@task_manager` is maybe better? `@task_scope_manager`?
  - [x] `ScopePerTaskNursery` is terrible.. how about `TaskScopedNursery`?
    - now i'm thinking you don't need much at all, `TaskManagerNursery`?
  - [x] `TaskOutcome.unwrap()` seems wrong, despite it being an example of 
        a user defined handle.
    - [x] @Fuyukai suggested `.wait_for_result()` which is a lot more
      pythonic in terms of plain-ol'-simple-semantics :surfer:
    - ~~maybe `.unwind()` is more descriptive? as in unwinding the outcome
      from the task would imply you both have to:~~
        - wait for the result or error from the underlying task
        - retrieve that outcome's value or raise it's error by unwrapping/boxing?
        - *stack unwinding* is normally synonymous with the end of
        a function call and the subsequent *popping of the stack* ..?
     - the nixed above ends up going down the rabbit hole of describing
        an imperative lang in terms of lower level fp abstractions which
        is not only confusing but a bit moot: we don't need to hear math
        about stuff we can't change in (python and) the semantics of
        a method..:joy:

- [ ] test the waters in `trio` core for interest in this idea
  - [x] had a decent discussion on it with the `anyio` author and njs but
    don't think they understood what i was proposing (hence this proto
    :joy:)
  - [ ] the main spot to start digging into how this might be implemented
    inside `trio`'s scheduler would be about here:
    https://github.com/python-trio/trio/blob/master/trio/_core/_run.py#L1601
    since this is where the nursery-global cancel scope's `CancelStatus`
    is activated on the currently spawning task.
    - obviously it's going to require quite a bit of reworking to try
      and offer the generator-style `@cancel_scope_manager` thing
      because we'll need to call `__enter__`/`__exit__` from two
      different `Runner` methods -> `.spawn_impl()` and `.task_exited()`
  - [ ] probably just eventually accept that no-one will comment on this
    PR (nor care?) and it'll get relegated to our `trionics` secret
    sauces pantry yet again :joy:

- [ ] figure out if it's possible to swap in **this** `open_nursery()`
  for all uses of `trio.open_nursery()` when our users enable debug mode
  :joy:
  - pretty sure we can do it at appropriate spots during (sub)actor boot?
    - root: https://github.com/goodboy/tractor/blob/master/tractor/_root.py#L135
    - child: https://github.com/goodboy/tractor/blob/master/tractor/_entry.py#L97


- [ ] review the `anyio` (WIP?) work around their version of an iface
  for this,
  - https://github.com/agronholm/anyio/pull/1098
    * https://github.com/agronholm/anyio/pull/1146
    * https://github.com/agronholm/anyio/pull/890
    * https://github.com/search?q=repo%3Aagronholm%2Fanyio+TaskHandle&type=pullrequests

- [ ] RECONDSIDER this whole task-oriented `tn` approach instead
     implementing the entire thing as just a `tn` of sub-`tn`s with
     each `tm.start[_soon]()` call simply opening another
     sub-`trio.Nursery` which would more or less provide the scope
     for "plugging-into" each single-`trio.Task`-under-lone-`tn`??

---

Maybe more to come?
