### PR TITLE
Start ` tractor.devx` sub-pkg

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -3,8 +3,8 @@
 |gh_actions|
 |docs|
 
-``tractor`` is a `structured concurrent`_, multi-processing_ runtime
-built on trio_.
+``tractor`` is a `structured concurrent`_, (optionally
+distributed_) multi-processing_ runtime built on trio_.
 
 Fundamentally, ``tractor`` gives you parallelism via
 ``trio``-"*actors*": independent Python processes (aka
@@ -17,11 +17,20 @@ protocol" constructed on top of multiple Pythons each running a ``trio``
 scheduled runtime - a call to ``trio.run()``.
 
 We believe the system adheres to the `3 axioms`_ of an "`actor model`_"
-but likely *does not* look like what *you* probably think an "actor
-model" looks like, and that's *intentional*.
+but likely **does not** look like what **you** probably *think* an "actor
+model" looks like, and that's **intentional**.
 
-The first step to grok ``tractor`` is to get the basics of ``trio`` down.
-A great place to start is the `trio docs`_ and this `blog post`_.
+
+Where do i start!?
+------------------
+The first step to grok ``tractor`` is to get an intermediate
+knowledge of ``trio`` and **structured concurrency** B)
+
+Some great places to start are,
+- the seminal `blog post`_
+- obviously the `trio docs`_
+- wikipedia's nascent SC_ page
+- the fancy diagrams @ libdill-docs_
 
 
 Features
@@ -593,6 +602,7 @@ matrix seems too hip, we're also mostly all in the the `trio gitter
 channel`_!
 
 .. _structured concurrent: https://trio.discourse.group/t/concise-definition-of-structured-concurrency/228
+.. _distributed: https://en.wikipedia.org/wiki/Distributed_computing
 .. _multi-processing: https://en.wikipedia.org/wiki/Multiprocessing
 .. _trio: https://github.com/python-trio/trio
 .. _nurseries: https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/#nurseries-a-structured-replacement-for-go-statements
@@ -611,8 +621,9 @@ channel`_!
 .. _trio docs: https://trio.readthedocs.io/en/latest/
 .. _blog post: https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/
 .. _structured concurrency: https://en.wikipedia.org/wiki/Structured_concurrency
+.. _SC: https://en.wikipedia.org/wiki/Structured_concurrency
+.. _libdill-docs: https://sustrik.github.io/libdill/structured-concurrency.html
 .. _structured chadcurrency: https://en.wikipedia.org/wiki/Structured_concurrency
-.. _structured concurrency: https://en.wikipedia.org/wiki/Structured_concurrency
 .. _unrequirements: https://en.wikipedia.org/wiki/Actor_model#Direct_communication_and_asynchrony
 .. _async generators: https://www.python.org/dev/peps/pep-0525/
 .. _trio-parallel: https://github.com/richardsheridan/trio-parallel

--- a/examples/debugging/asyncio_bp.py
+++ b/examples/debugging/asyncio_bp.py
@@ -1,0 +1,79 @@
+import asyncio
+
+import trio
+import tractor
+
+
+async def bp_then_error(
+    to_trio: trio.MemorySendChannel,
+    from_trio: asyncio.Queue,
+
+) -> None:
+
+    # sync with ``trio``-side (caller) task
+    to_trio.send_nowait('start')
+
+    # NOTE: what happens here inside the hook needs some refinement..
+    # => seems like it's still `._debug._set_trace()` but
+    #    we set `Lock.local_task_in_debug = 'sync'`, we probably want
+    #    some further, at least, meta-data about the task/actoq in debug
+    #    in terms of making it clear it's asyncio mucking about.
+
+    breakpoint()
+
+    await asyncio.sleep(0.5)
+    raise ValueError('blah')
+
+
+async def aio_sleep_forever():
+    await asyncio.sleep(float('inf'))
+
+
+@tractor.context
+async def trio_ctx(
+    ctx: tractor.Context,
+):
+
+    # this will block until the ``asyncio`` task sends a "first"
+    # message, see first line in above func.
+    async with (
+        tractor.to_asyncio.open_channel_from(bp_then_error) as (first, chan),
+        trio.open_nursery() as n,
+    ):
+
+        assert first == 'start'
+        await ctx.started(first)
+
+        n.start_soon(
+            tractor.to_asyncio.run_task,
+            aio_sleep_forever,
+        )
+        await trio.sleep_forever()
+
+
+async def main():
+
+    async with tractor.open_nursery() as n:
+
+        p = await n.start_actor(
+            'aio_daemon',
+            enable_modules=[__name__],
+            infect_asyncio=True,
+            debug_mode=True,
+            loglevel='cancel',
+        )
+
+        async with p.open_context(trio_ctx) as (ctx, first):
+
+            assert first == 'start'
+            await trio.sleep_forever()
+
+            assert 0
+
+        # TODO: case where we cancel from trio-side while asyncio task
+        # has debugger lock?
+        # await p.cancel_actor()
+
+
+if __name__ == '__main__':
+    trio.run(main)

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'tractor.trionics',  # trio extensions
         'tractor.msg',  # lowlevel data types
         'tractor._testing',  # internal cross-subsys suite utils
+        'tractor.devx',  # "dev-experience"
     ],
     install_requires=[
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open('docs/README.rst', encoding='utf-8') as f:
 setup(
     name="tractor",
     version='0.1.0a6dev0',  # alpha zone
-    description='structured concurrrent `trio`-"actors"',
+    description='structured concurrent `trio`-"actors"',
     long_description=readme,
     license='AGPLv3',
     author='Tyler Goodlet',
@@ -53,6 +53,7 @@ setup(
         # 'exceptiongroup',  # in stdlib as of 3.11!
 
         # tooling
+        'stackscope',
         'tricycle',
         'trio_typing',
         'colorlog',
@@ -64,15 +65,14 @@ setup(
         # debug mode REPL
         'pdbp',
 
+        # TODO: distributed transport using
+        # linux kernel networking
+        # 'pyroute2',
+
         # pip ref docs on these specs:
         # https://pip.pypa.io/en/stable/reference/requirement-specifiers/#examples
         # and pep:
         # https://peps.python.org/pep-0440/#version-specifiers
-
-        # windows deps workaround for ``pdbpp``
-        # https://github.com/pdbpp/pdbpp/issues/498
-        # https://github.com/pdbpp/fancycompleter/issues/37
-        'pyreadline3 ; platform_system == "Windows"',
 
     ],
     tests_require=['pytest'],

--- a/tests/test_context_stream_semantics.py
+++ b/tests/test_context_stream_semantics.py
@@ -245,10 +245,10 @@ def test_simple_context(
             trio.run(main)
         except error_parent:
             pass
-        except trio.MultiError as me:
+        except BaseExceptionGroup as beg:
             # XXX: on windows it seems we may have to expect the group error
             from tractor._exceptions import is_multi_cancelled
-            assert is_multi_cancelled(me)
+            assert is_multi_cancelled(beg)
     else:
         trio.run(main)
 

--- a/tests/test_legacy_one_way_streaming.py
+++ b/tests/test_legacy_one_way_streaming.py
@@ -38,10 +38,13 @@ async def async_gen_stream(sequence):
     assert cs.cancelled_caught
 
 
+# TODO: deprecated either remove entirely
+# or re-impl in terms of `MsgStream` one-sides
+# wrapper, but at least remove `Portal.open_stream_from()`
 @tractor.stream
 async def context_stream(
     ctx: tractor.Context,
-    sequence
+    sequence: list[int],
 ):
     for i in sequence:
         await ctx.send_yield(i)

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -46,6 +46,9 @@ from ._exceptions import (
 )
 from ._debug import (
     breakpoint,
+    pause,
+    pp,
+    pause_from_sync,
     post_mortem,
 )
 from . import msg
@@ -59,12 +62,12 @@ from ._runtime import Actor
 
 __all__ = [
     'Actor',
+    'BaseExceptionGroup',
     'Channel',
     'Context',
     'ContextCancelled',
     'ModuleNotExposed',
     'MsgStream',
-    'BaseExceptionGroup',
     'Portal',
     'RemoteActorError',
     'breakpoint',
@@ -77,7 +80,10 @@ __all__ = [
     'open_actor_cluster',
     'open_nursery',
     'open_root_actor',
+    'pause',
     'post_mortem',
+    'pp',
+    'pause_from_sync'
     'query_actor',
     'run_daemon',
     'stream',

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -43,7 +43,7 @@ from ._exceptions import (
     ModuleNotExposed,
     ContextCancelled,
 )
-from ._debug import (
+from .devx import (
     breakpoint,
     pause,
     pause_from_sync,

--- a/tractor/__init__.py
+++ b/tractor/__init__.py
@@ -19,7 +19,6 @@ tractor: structured concurrent ``trio``-"actors".
 
 """
 from ._clustering import open_actor_cluster
-from ._ipc import Channel
 from ._context import (
     Context,  # the type
     context,  # a func-decorator
@@ -47,7 +46,6 @@ from ._exceptions import (
 from ._debug import (
     breakpoint,
     pause,
-    pp,
     pause_from_sync,
     post_mortem,
 )
@@ -56,6 +54,7 @@ from ._root import (
     run_daemon,
     open_root_actor,
 )
+from ._ipc import Channel
 from ._portal import Portal
 from ._runtime import Actor
 
@@ -74,6 +73,7 @@ __all__ = [
     'context',
     'current_actor',
     'find_actor',
+    'query_actor',
     'get_arbiter',
     'is_root_process',
     'msg',
@@ -82,8 +82,7 @@ __all__ = [
     'open_root_actor',
     'pause',
     'post_mortem',
-    'pp',
-    'pause_from_sync'
+    'pause_from_sync',
     'query_actor',
     'run_daemon',
     'stream',

--- a/tractor/_context.py
+++ b/tractor/_context.py
@@ -868,6 +868,9 @@ class Context:
 
         # TODO: maybe we should also call `._res_scope.cancel()` if it
         # exists to support cancelling any drain loop hangs?
+        # NOTE: this usage actually works here B)
+        # from .devx._debug import breakpoint
+        # await breakpoint()
 
     # TODO: add to `Channel`?
     @property

--- a/tractor/_context.py
+++ b/tractor/_context.py
@@ -313,7 +313,7 @@ async def _drain_to_final_msg(
                 log.critical('SHOULD NEVER GET HERE!?')
                 assert msg is ctx._cancel_msg
                 assert error.msgdata == ctx._remote_error.msgdata
-                from ._debug import pause
+                from .devx._debug import pause
                 await pause()
                 ctx._maybe_cancel_and_set_remote_error(error)
                 ctx._maybe_raise_remote_err(error)
@@ -2202,7 +2202,7 @@ async def open_context_from_portal(
             #     pass
             # TODO: factor ^ into below for non-root cases?
             #
-            from ._debug import maybe_wait_for_debugger
+            from .devx._debug import maybe_wait_for_debugger
             was_acquired: bool = await maybe_wait_for_debugger(
                 # header_msg=(
                 #     'Delaying `ctx.cancel()` until debug lock '
@@ -2313,7 +2313,7 @@ async def open_context_from_portal(
         # where the root is waiting on the lock to clear but the
         # child has already cleared it and clobbered IPC.
         if debug_mode():
-            from ._debug import maybe_wait_for_debugger
+            from .devx._debug import maybe_wait_for_debugger
             await maybe_wait_for_debugger()
 
         # though it should be impossible for any tasks

--- a/tractor/_root.py
+++ b/tractor/_root.py
@@ -90,7 +90,7 @@ async def open_root_actor(
     # https://github.com/python-trio/trio/issues/1155#issuecomment-742964018
     builtin_bp_handler = sys.breakpointhook
     orig_bp_path: str | None = os.environ.get('PYTHONBREAKPOINT', None)
-    os.environ['PYTHONBREAKPOINT'] = 'tractor._debug._set_trace'
+    os.environ['PYTHONBREAKPOINT'] = 'tractor._debug.pause_from_sync'
 
     # attempt to retreive ``trio``'s sigint handler and stash it
     # on our debugger lock state.
@@ -237,10 +237,10 @@ async def open_root_actor(
             ) as err:
 
                 entered = await _debug._maybe_enter_pm(err)
-
                 if (
                     not entered
-                    and not is_multi_cancelled(err)
+                    and
+                    not is_multi_cancelled(err)
                 ):
                     logger.exception('Root actor crashed:\n')
 

--- a/tractor/_root.py
+++ b/tractor/_root.py
@@ -38,7 +38,7 @@ from ._runtime import (
     # Arbiter as Registry,
     async_main,
 )
-from . import _debug
+from .devx import _debug
 from . import _spawn
 from . import _state
 from . import log
@@ -90,7 +90,7 @@ async def open_root_actor(
     # https://github.com/python-trio/trio/issues/1155#issuecomment-742964018
     builtin_bp_handler = sys.breakpointhook
     orig_bp_path: str | None = os.environ.get('PYTHONBREAKPOINT', None)
-    os.environ['PYTHONBREAKPOINT'] = 'tractor._debug.pause_from_sync'
+    os.environ['PYTHONBREAKPOINT'] = 'tractor.devx._debug.pause_from_sync'
 
     # attempt to retreive ``trio``'s sigint handler and stash it
     # on our debugger lock state.
@@ -138,7 +138,7 @@ async def open_root_actor(
 
         # expose internal debug module to every actor allowing
         # for use of ``await tractor.breakpoint()``
-        enable_modules.append('tractor._debug')
+        enable_modules.append('tractor.devx._debug')
 
         # if debug mode get's enabled *at least* use that level of
         # logging for some informative console prompts.

--- a/tractor/_rpc.py
+++ b/tractor/_rpc.py
@@ -55,7 +55,7 @@ from ._exceptions import (
     unpack_error,
     TransportClosed,
 )
-from . import _debug
+from .devx import _debug
 from . import _state
 from .log import get_logger
 

--- a/tractor/_runtime.py
+++ b/tractor/_runtime.py
@@ -632,7 +632,7 @@ class Actor:
                         and not db_cs.cancel_called
                         and uid == pdb_user_uid
                     ):
-                        log.warning(
+                        log.critical(
                             f'STALE DEBUG LOCK DETECTED FOR {uid}'
                         )
                         # TODO: figure out why this breaks tests..

--- a/tractor/_runtime.py
+++ b/tractor/_runtime.py
@@ -1722,4 +1722,6 @@ class Arbiter(Actor):
 
     ) -> None:
         uid = (str(uid[0]), str(uid[1]))
-        self._registry.pop(uid)
+        entry: tuple = self._registry.pop(uid, None)
+        if entry is None:
+            log.warning(f'Request to de-register {uid} failed?')

--- a/tractor/_runtime.py
+++ b/tractor/_runtime.py
@@ -78,7 +78,7 @@ from ._exceptions import (
     TransportClosed,
 )
 from ._discovery import get_arbiter
-from . import _debug
+from .devx import _debug
 from ._portal import Portal
 from . import _state
 from . import _mp_fixup_main
@@ -187,7 +187,7 @@ class Actor:
         self._parent_main_data = _mp_fixup_main._mp_figure_out_main()
 
         # always include debugging tools module
-        enable_modules.append('tractor._debug')
+        enable_modules.append('tractor.devx._debug')
 
         mods = {}
         for name in enable_modules:

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -551,13 +551,14 @@ async def trio_proc(
                         with trio.move_on_after(0.5):
                             await proc.wait()
 
-                log.pdb(
-                    'Delaying subproc reaper while debugger locked..'
-                )
                 await maybe_wait_for_debugger(
                     child_in_debug=_runtime_vars.get(
                         '_debug_mode', False
                     ),
+                    header_msg=(
+                        'Delaying subproc reaper while debugger locked..\n'
+                    ),
+
                     # TODO: need a diff value then default?
                     # poll_steps=9999999,
                 )

--- a/tractor/_spawn.py
+++ b/tractor/_spawn.py
@@ -34,7 +34,7 @@ from typing import (
 import trio
 from trio import TaskStatus
 
-from ._debug import (
+from .devx._debug import (
     maybe_wait_for_debugger,
     acquire_debug_lock,
 )

--- a/tractor/_supervise.py
+++ b/tractor/_supervise.py
@@ -31,7 +31,7 @@ import warnings
 
 import trio
 
-from ._debug import maybe_wait_for_debugger
+from .devx._debug import maybe_wait_for_debugger
 from ._state import current_actor, is_main_process
 from .log import get_logger, get_loglevel
 from ._runtime import Actor

--- a/tractor/devx/__init__.py
+++ b/tractor/devx/__init__.py
@@ -1,0 +1,45 @@
+# tractor: structured concurrent "actors".
+# Copyright 2018-eternity Tyler Goodlet.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Runtime "developer experience" utils and addons to aid our
+(advanced) users and core devs in building distributed applications
+and working with/on the actor runtime.
+
+"""
+from ._debug import (
+    maybe_wait_for_debugger,
+    acquire_debug_lock,
+    breakpoint,
+    pause,
+    pause_from_sync,
+    shield_sigint_handler,
+    MultiActorPdb,
+    open_crash_handler,
+    post_mortem,
+)
+
+__all__ = [
+    'maybe_wait_for_debugger',
+    'acquire_debug_lock',
+    'breakpoint',
+    'pause',
+    'pause_from_sync',
+    'shield_sigint_handler',
+    'MultiActorPdb',
+    'open_crash_handler',
+    'post_mortem',
+]

--- a/tractor/devx/__init__.py
+++ b/tractor/devx/__init__.py
@@ -32,6 +32,9 @@ from ._debug import (
     maybe_open_crash_handler,
     post_mortem,
 )
+from ._stackscope import (
+    enable_stack_on_sig as enable_stack_on_sig,
+)
 
 __all__ = [
     'maybe_wait_for_debugger',

--- a/tractor/devx/__init__.py
+++ b/tractor/devx/__init__.py
@@ -29,6 +29,7 @@ from ._debug import (
     shield_sigint_handler,
     MultiActorPdb,
     open_crash_handler,
+    maybe_open_crash_handler,
     post_mortem,
 )
 
@@ -41,5 +42,6 @@ __all__ = [
     'shield_sigint_handler',
     'MultiActorPdb',
     'open_crash_handler',
+    'maybe_open_crash_handler',
     'post_mortem',
 ]

--- a/tractor/devx/__init__.py
+++ b/tractor/devx/__init__.py
@@ -21,30 +21,17 @@ and working with/on the actor runtime.
 
 """
 from ._debug import (
-    maybe_wait_for_debugger,
-    acquire_debug_lock,
-    breakpoint,
-    pause,
-    pause_from_sync,
-    shield_sigint_handler,
-    MultiActorPdb,
-    open_crash_handler,
-    maybe_open_crash_handler,
-    post_mortem,
+    maybe_wait_for_debugger as maybe_wait_for_debugger,
+    acquire_debug_lock as acquire_debug_lock,
+    breakpoint as breakpoint,
+    pause as pause,
+    pause_from_sync as pause_from_sync,
+    shield_sigint_handler as shield_sigint_handler,
+    MultiActorPdb as MultiActorPdb,
+    open_crash_handler as open_crash_handler,
+    maybe_open_crash_handler as maybe_open_crash_handler,
+    post_mortem as post_mortem,
 )
 from ._stackscope import (
     enable_stack_on_sig as enable_stack_on_sig,
 )
-
-__all__ = [
-    'maybe_wait_for_debugger',
-    'acquire_debug_lock',
-    'breakpoint',
-    'pause',
-    'pause_from_sync',
-    'shield_sigint_handler',
-    'MultiActorPdb',
-    'open_crash_handler',
-    'maybe_open_crash_handler',
-    'post_mortem',
-]

--- a/tractor/devx/_debug.py
+++ b/tractor/devx/_debug.py
@@ -682,7 +682,7 @@ async def pause(
     https://en.wikipedia.org/wiki/Breakpoint
 
     '''
-    __tracebackhide__ = True
+    # __tracebackhide__ = True
     actor = tractor.current_actor()
     pdb, undo_sigint = mk_mpdb()
     task_name = trio.lowlevel.current_task().name
@@ -836,25 +836,32 @@ async def pause(
 # runtime aware version which takes care of all .
 def pause_from_sync() -> None:
     print("ENTER SYNC PAUSE")
-    try:
-        import greenback
-        __tracebackhide__ = True
+    actor: tractor.Actor = tractor.current_actor(
+        err_on_no_runtime=False,
+    )
+    if actor:
+        try:
+            import greenback
+            # __tracebackhide__ = True
 
-        actor: tractor.Actor = tractor.current_actor()
-        # task_can_release_tty_lock = trio.Event()
 
-        # spawn bg task which will lock out the TTY, we poll
-        # just below until the release event is reporting that task as
-        # waiting.. not the most ideal but works for now ;)
-        greenback.await_(
-            actor._service_n.start(partial(
-                pause,
-                debug_func=None,
-                # release_lock_signal=task_can_release_tty_lock,
-            ))
-        )
-    except ModuleNotFoundError:
-        log.warning('NO GREENBACK FOUND')
+            # task_can_release_tty_lock = trio.Event()
+
+            # spawn bg task which will lock out the TTY, we poll
+            # just below until the release event is reporting that task as
+            # waiting.. not the most ideal but works for now ;)
+            greenback.await_(
+                actor._service_n.start(partial(
+                    pause,
+                    debug_func=None,
+                    # release_lock_signal=task_can_release_tty_lock,
+                ))
+            )
+
+        except ModuleNotFoundError:
+            log.warning('NO GREENBACK FOUND')
+    else:
+        log.warning('Not inside actor-runtime')
 
     db, undo_sigint = mk_mpdb()
     Lock.local_task_in_debug = 'sync'

--- a/tractor/devx/_debug.py
+++ b/tractor/devx/_debug.py
@@ -847,7 +847,7 @@ def pause_from_sync() -> None:
     # waiting.. not the most ideal but works for now ;)
     greenback.await_(
         actor._service_n.start(partial(
-            _pause,
+            pause,
             debug_func=None,
             # release_lock_signal=task_can_release_tty_lock,
         ))

--- a/tractor/devx/_debug.py
+++ b/tractor/devx/_debug.py
@@ -1041,15 +1041,19 @@ async def maybe_wait_for_debugger(
 
 
 # TODO: better naming and what additionals?
-# - optional runtime plugging?
-# - detection for sync vs. async code?
-# - specialized REPL entry when in distributed mode?
+# - [ ] optional runtime plugging?
+# - [ ] detection for sync vs. async code?
+# - [ ] specialized REPL entry when in distributed mode?
+# - [x] allow ignoring kbi Bo
 @cm
 def open_crash_handler(
     catch: set[BaseException] = {
         Exception,
         BaseException,
-    }
+    },
+    ignore: set[BaseException] = {
+        KeyboardInterrupt,
+    },
 ):
     '''
     Generic "post mortem" crash handler using `pdbp` REPL debugger.
@@ -1064,8 +1068,11 @@ def open_crash_handler(
     '''
     try:
         yield
-    except tuple(catch):
-        pdbp.xpm()
+    except tuple(catch) as err:
+
+        if type(err) not in ignore:
+            pdbp.xpm()
+
         raise
 
 

--- a/tractor/devx/_debug.py
+++ b/tractor/devx/_debug.py
@@ -836,22 +836,25 @@ async def pause(
 # runtime aware version which takes care of all .
 def pause_from_sync() -> None:
     print("ENTER SYNC PAUSE")
-    import greenback
-    __tracebackhide__ = True
+    try:
+        import greenback
+        __tracebackhide__ = True
 
-    actor: tractor.Actor = tractor.current_actor()
-    # task_can_release_tty_lock = trio.Event()
+        actor: tractor.Actor = tractor.current_actor()
+        # task_can_release_tty_lock = trio.Event()
 
-    # spawn bg task which will lock out the TTY, we poll
-    # just below until the release event is reporting that task as
-    # waiting.. not the most ideal but works for now ;)
-    greenback.await_(
-        actor._service_n.start(partial(
-            pause,
-            debug_func=None,
-            # release_lock_signal=task_can_release_tty_lock,
-        ))
-    )
+        # spawn bg task which will lock out the TTY, we poll
+        # just below until the release event is reporting that task as
+        # waiting.. not the most ideal but works for now ;)
+        greenback.await_(
+            actor._service_n.start(partial(
+                pause,
+                debug_func=None,
+                # release_lock_signal=task_can_release_tty_lock,
+            ))
+        )
+    except ModuleNotFoundError:
+        log.warning('NO GREENBACK FOUND')
 
     db, undo_sigint = mk_mpdb()
     Lock.local_task_in_debug = 'sync'

--- a/tractor/devx/_debug.py
+++ b/tractor/devx/_debug.py
@@ -49,7 +49,6 @@ from trio_typing import (
 )
 
 from ..log import get_logger
-from .._discovery import get_root
 from .._state import (
     is_root_process,
     debug_mode,
@@ -331,7 +330,7 @@ async def lock_tty_for_child(
             f'Actor {subactor_uid} is blocked from acquiring debug lock\n'
             f"remote task: {task_name}:{subactor_uid}"
         )
-        ctx._enter_debugger_on_cancel = False
+        ctx._enter_debugger_on_cancel: bool = False
         await ctx.cancel(f'Debug lock blocked for {subactor_uid}')
         return 'pdb_lock_blocked'
 
@@ -388,6 +387,8 @@ async def wait_for_parent_stdin_hijack(
     ``maybe_wait_for_debugger()``).
 
     '''
+    from .._discovery import get_root
+
     with trio.CancelScope(shield=True) as cs:
         Lock._debugger_request_cs = cs
 
@@ -611,7 +612,7 @@ def _set_trace(
     pdb: MultiActorPdb | None = None,
     shield: bool = False,
 ):
-    __tracebackhide__ = True
+    __tracebackhide__: bool = True
     actor: tractor.Actor = actor or tractor.current_actor()
 
     # start 2 levels up in user code

--- a/tractor/devx/_debug.py
+++ b/tractor/devx/_debug.py
@@ -27,8 +27,10 @@ from functools import (
     partial,
     cached_property,
 )
-from contextlib import asynccontextmanager as acm
-from contextlib import contextmanager as cm
+from contextlib import (
+    asynccontextmanager as acm,
+    contextmanager as cm,
+)
 from typing import (
     Any,
     Callable,

--- a/tractor/devx/_debug.py
+++ b/tractor/devx/_debug.py
@@ -30,6 +30,7 @@ from functools import (
 from contextlib import (
     asynccontextmanager as acm,
     contextmanager as cm,
+    nullcontext,
 )
 from typing import (
     Any,
@@ -1043,3 +1044,20 @@ def open_crash_handler(
     except tuple(catch):
         pdbp.xpm()
         raise
+
+
+@cm
+def maybe_open_crash_handler(pdb: bool = False):
+    '''
+    Same as `open_crash_handler()` but with bool input flag
+    to allow conditional handling.
+
+    Normally this is used with CLI endpoints such that if the --pdb
+    flag is passed the pdb REPL is engaed on any crashes B)
+    '''
+    rtctx = nullcontext
+    if pdb:
+        rtctx = open_crash_handler
+
+    with rtctx():
+        yield

--- a/tractor/devx/_stackscope.py
+++ b/tractor/devx/_stackscope.py
@@ -1,0 +1,84 @@
+# tractor: structured concurrent "actors".
+# Copyright eternity Tyler Goodlet.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+'''
+The fundamental cross process SC abstraction: an inter-actor,
+cancel-scope linked task "context".
+
+A ``Context`` is very similar to the ``trio.Nursery.cancel_scope`` built
+into each ``trio.Nursery`` except it links the lifetimes of memory space
+disjoint, parallel executing tasks in separate actors.
+
+'''
+from signal import (
+    signal,
+    SIGUSR1,
+)
+
+import trio
+
+@trio.lowlevel.disable_ki_protection
+def dump_task_tree() -> None:
+    import stackscope
+    from tractor.log import get_console_log
+
+    tree_str: str = str(
+        stackscope.extract(
+            trio.lowlevel.current_root_task(),
+            recurse_child_tasks=True
+        )
+    )
+    log = get_console_log('cancel')
+    log.pdb(
+        f'Dumping `stackscope` tree:\n\n'
+        f'{tree_str}\n'
+    )
+    # import logging
+    # try:
+    #     with open("/dev/tty", "w") as tty:
+    #         tty.write(tree_str)
+    # except BaseException:
+    #     logging.getLogger(
+    #         "task_tree"
+    #     ).exception("Error printing task tree")
+
+
+def signal_handler(sig: int, frame: object) -> None:
+    import traceback
+    try:
+        trio.lowlevel.current_trio_token(
+        ).run_sync_soon(dump_task_tree)
+    except RuntimeError:
+        # not in async context -- print a normal traceback
+        traceback.print_stack()
+
+
+
+def enable_stack_on_sig(
+    sig: int = SIGUSR1
+) -> None:
+    '''
+    Enable `stackscope` tracing on reception of a signal; by
+    default this is SIGUSR1.
+
+    '''
+    signal(
+        sig,
+        signal_handler,
+    )
+    # NOTE: not the above can be triggered from
+    # a (xonsh) shell using:
+    # kill -SIGUSR1 @$(pgrep -f '<cmd>')

--- a/tractor/devx/cli.py
+++ b/tractor/devx/cli.py
@@ -1,0 +1,149 @@
+# tractor: structured concurrent "actors".
+# Copyright 2018-eternity Tyler Goodlet.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+CLI framework extensions for hacking on the actor runtime.
+
+Currently popular frameworks supported are:
+
+  - `typer` via the `@callback` API
+
+"""
+from __future__ import annotations
+from contextlib import (
+    # asynccontextmanager as acm,
+    nullcontext,
+    contextmanager as cm,
+)
+from typing import (
+    Any,
+    Callable,
+)
+from typing_extensions import Annotated
+
+import typer
+
+
+from ._debug import open_crash_handler
+
+
+_runtime_vars: dict[str, Any] = {}
+
+
+def load_runtime_vars(
+    ctx: typer.Context,
+    callback: Callable,
+    pdb: bool = False,  # --pdb
+    ll: Annotated[
+        str,
+        typer.Option(
+            '--loglevel',
+            '-l',
+            help='BigD logging level',
+        ),
+    ] = 'cancel',  # -l info
+):
+    '''
+    Maybe engage crash handling with `pdbp` when code inside
+    a `typer` CLI endpoint cmd raises.
+
+    To use this callback simply take your `app = typer.Typer()` instance
+    and decorate this function with it like so:
+
+    .. code:: python
+
+        from tractor.devx import cli
+
+        app = typer.Typer()
+
+        # manual decoration to hook into `click`'s context system!
+        cli.load_runtime_vars = app.callback(
+            invoke_without_command=True,
+        )
+
+    And then you can use the now augmented `click` CLI context as so,
+
+    .. code:: python
+
+        @app.command(
+            context_settings={
+                "allow_extra_args": True,
+                "ignore_unknown_options": True,
+            }
+        )
+        def my_cli_cmd(
+            ctx: typer.Context,
+        ):
+            rtvars: dict = ctx.runtime_vars
+            pdb: bool = rtvars['pdb']
+
+            with tractor.devx.cli.maybe_open_crash_handler(pdb=pdb):
+                trio.run(
+                    partial(
+                        my_tractor_main_task_func,
+                        debug_mode=pdb,
+                        loglevel=rtvars['ll'],
+                    )
+                )
+
+    which will enable log level and debug mode globally for the entire
+    `tractor` + `trio` runtime thereafter!
+
+    Bo
+
+    '''
+    global _runtime_vars
+    _runtime_vars |= {
+        'pdb': pdb,
+        'll': ll,
+    }
+
+    ctx.runtime_vars: dict[str, Any] = _runtime_vars
+    print(
+        f'`typer` sub-cmd: {ctx.invoked_subcommand}\n'
+        f'`tractor` runtime vars: {_runtime_vars}'
+    )
+
+    # XXX NOTE XXX: hackzone.. if no sub-cmd is specified (the
+    # default if the user just invokes `bigd`) then we simply
+    # invoke the sole `_bigd()` cmd passing in the "parent"
+    # typer.Context directly to that call since we're treating it
+    # as a "non sub-command" or wtv..
+    # TODO: ideally typer would have some kinda built-in way to get
+    # this behaviour without having to construct and manually
+    # invoke our own cmd..
+    if (
+        ctx.invoked_subcommand is None
+        or ctx.invoked_subcommand == callback.__name__
+    ):
+        cmd: typer.core.TyperCommand = typer.core.TyperCommand(
+            name='bigd',
+            callback=callback,
+        )
+        ctx.params = {'ctx': ctx}
+        cmd.invoke(ctx)
+
+
+@cm
+def maybe_open_crash_handler(pdb: bool = False):
+    # if the --pdb flag is passed always engage
+    # the pdb REPL on any crashes B)
+    rtctx = nullcontext
+    if pdb:
+        rtctx = open_crash_handler
+
+    with rtctx():
+        yield

--- a/tractor/devx/cli.py
+++ b/tractor/devx/cli.py
@@ -23,10 +23,6 @@ Currently popular frameworks supported are:
 
 """
 from __future__ import annotations
-from contextlib import (
-    # asynccontextmanager as acm,
-    contextmanager as cm,
-)
 from typing import (
     Any,
     Callable,
@@ -34,9 +30,6 @@ from typing import (
 from typing_extensions import Annotated
 
 import typer
-
-
-from ._debug import open_crash_handler
 
 
 _runtime_vars: dict[str, Any] = {}

--- a/tractor/devx/cli.py
+++ b/tractor/devx/cli.py
@@ -25,7 +25,6 @@ Currently popular frameworks supported are:
 from __future__ import annotations
 from contextlib import (
     # asynccontextmanager as acm,
-    nullcontext,
     contextmanager as cm,
 )
 from typing import (
@@ -135,15 +134,3 @@ def load_runtime_vars(
         )
         ctx.params = {'ctx': ctx}
         cmd.invoke(ctx)
-
-
-@cm
-def maybe_open_crash_handler(pdb: bool = False):
-    # if the --pdb flag is passed always engage
-    # the pdb REPL on any crashes B)
-    rtctx = nullcontext
-    if pdb:
-        rtctx = open_crash_handler
-
-    with rtctx():
-        yield

--- a/tractor/to_asyncio.py
+++ b/tractor/to_asyncio.py
@@ -28,7 +28,6 @@ from typing import (
     Callable,
     AsyncIterator,
     Awaitable,
-    Optional,
 )
 
 import trio
@@ -65,9 +64,9 @@ class LinkedTaskChannel(trio.abc.Channel):
     _trio_exited: bool = False
 
     # set after ``asyncio.create_task()``
-    _aio_task: Optional[asyncio.Task] = None
-    _aio_err: Optional[BaseException] = None
-    _broadcaster: Optional[BroadcastReceiver] = None
+    _aio_task: asyncio.Task | None = None
+    _aio_err: BaseException | None = None
+    _broadcaster: BroadcastReceiver | None = None
 
     async def aclose(self) -> None:
         await self._from_aio.aclose()
@@ -188,7 +187,7 @@ def _run_asyncio_task(
 
     cancel_scope = trio.CancelScope()
     aio_task_complete = trio.Event()
-    aio_err: Optional[BaseException] = None
+    aio_err: BaseException | None = None
 
     chan = LinkedTaskChannel(
         aio_q,  # asyncio.Queue
@@ -270,7 +269,7 @@ def _run_asyncio_task(
         '''
         nonlocal chan
         aio_err = chan._aio_err
-        task_err: Optional[BaseException] = None
+        task_err: BaseException | None = None
 
         # only to avoid ``asyncio`` complaining about uncaptured
         # task exceptions
@@ -350,11 +349,11 @@ async def translate_aio_errors(
     '''
     trio_task = trio.lowlevel.current_task()
 
-    aio_err: Optional[BaseException] = None
+    aio_err: BaseException | None = None
 
     # TODO: make thisi a channel method?
     def maybe_raise_aio_err(
-        err: Optional[Exception] = None
+        err: Exception | None = None
     ) -> None:
         aio_err = chan._aio_err
         if (


### PR DESCRIPTION
As a place to start organizing all our *developer experience* tools
and subsystems including,

- `._debug`: our multi-process-safe debugger REPL using `pdbp`
- `.pretty_struct`: holds some minor extensions to `msgspec.Struct`
  for prettier console `repr()`.
- `._stackscope`: draft support for using the lovely
  [`stackscope`](https://github.com/oremanj/stackscope) to render
  task per-actor stack-trees on `SIGUSR1` for tracing hanging
  `trio`/`tractor` apps.
- `.cli`: for now an optional idea for a `typer`/`click` plugin-hook
  thing to enable capturing `--pdb` and `--ll` flags via a `ctx:
  typer.Context.runtime_vars: dict`; something pulled out of a client
  repo-project.

---

#### Key new `.devx` subsys features:
- very very early draft support for using
  [`greenback`](https://github.com/oremanj/greenback) to implement
  `tractor.pause_from_sync()` from sync functions.
- mapping `breakpoint()` to an early draft-ish impl of
  `tractor.pause_from_sync()`
- fixes and extensions to `.devx.maybe_wait_for_debugger()`.

---

#### Also included,
- `asyncio` mode debugger example script(s)
- debug-mode example script which replicates a SIGINT-shielding and then hang..
- expose `tractor.Channel`
- drop `tractor.pp()` alias
