### PR TITLE
`to_asyncio` eoc signal: use `trio.EndOfChannel` to indicate (maybe non-graceful) `asyncio.Task` termination

### DIFF
--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -1089,10 +1089,14 @@ def test_sigint_closes_lifetime_stack(
 
 
 
-# asyncio.Task fn
+# ?TODO asyncio.Task fn-deco?
+# -[ ] do sig checkingat import time like @context?
+# -[ ] maybe name it @aio_task ??
+# -[ ] chan: to_asyncio.InterloopChannel ??
 async def raise_before_started(
-    from_trio: asyncio.Queue,
-    to_trio: trio.abc.SendChannel,
+    # from_trio: asyncio.Queue,
+    # to_trio: trio.abc.SendChannel,
+    chan: to_asyncio.LinkedTaskChannel,
 
 ) -> None:
     '''
@@ -1103,7 +1107,8 @@ async def raise_before_started(
     await asyncio.sleep(0.2)
     raise RuntimeError('Some shite went wrong before `.send_nowait()`!!')
 
-    to_trio.send_nowait('Uhh we shouldve RTE-d ^^ ??')
+    # to_trio.send_nowait('Uhh we shouldve RTE-d ^^ ??')
+    chan.started_nowait('Uhh we shouldve RTE-d ^^ ??')
     await asyncio.sleep(float('inf'))
 
 
@@ -1145,12 +1150,18 @@ async def caching_ep(
         await trio.sleep_forever()
 
 
-# TODO, simulates connection-err from `piker.brokers.ib.api`..
 def test_aio_side_raises_before_started(
     reg_addr: tuple[str, int],
     debug_mode: bool,
     loglevel: str,
 ):
+    '''
+    Simulates connection-err from `piker.brokers.ib.api`..
+
+    Ensure any error raised by child-`asyncio.Task` BEFORE
+    `chan.started()`
+
+    '''
     # delay = 999 if debug_mode else 1
     async def main():
         with trio.fail_after(3):

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -571,14 +571,16 @@ def test_basic_interloop_channel_stream(
     fan_out: bool,
 ):
     async def main():
-        async with tractor.open_nursery() as an:
-            portal = await an.run_in_actor(
-                stream_from_aio,
-                infect_asyncio=True,
-                fan_out=fan_out,
-            )
-            # should raise RAE diectly
-            await portal.result()
+        # TODO, figure out min timeout here!
+        with trio.fail_after(6):
+            async with tractor.open_nursery() as an:
+                portal = await an.run_in_actor(
+                    stream_from_aio,
+                    infect_asyncio=True,
+                    fan_out=fan_out,
+                )
+                # should raise RAE diectly
+                await portal.result()
 
     trio.run(main)
 
@@ -1085,6 +1087,97 @@ def test_sigint_closes_lifetime_stack(
 
     trio.run(main)
 
+
+
+# asyncio.Task fn
+async def raise_before_started(
+    from_trio: asyncio.Queue,
+    to_trio: trio.abc.SendChannel,
+
+) -> None:
+    '''
+    `asyncio.Task` entry point which RTEs before calling
+    `to_trio.send_nowait()`.
+
+    '''
+    await asyncio.sleep(0.2)
+    raise RuntimeError('Some shite went wrong before `.send_nowait()`!!')
+
+    to_trio.send_nowait('Uhh we shouldve RTE-d ^^ ??')
+    await asyncio.sleep(float('inf'))
+
+
+@tractor.context
+async def caching_ep(
+    ctx: tractor.Context,
+):
+
+    log = tractor.log.get_logger('caching_ep')
+    log.info('syncing via `ctx.started()`')
+    await ctx.started()
+
+    # XXX, allocate the `open_channel_from()` inside
+    # a `.trionics.maybe_open_context()`.
+    chan: to_asyncio.LinkedTaskChannel
+    async with (
+        tractor.trionics.maybe_open_context(
+            acm_func=tractor.to_asyncio.open_channel_from,
+            kwargs={
+                'target': raise_before_started,
+                # ^XXX, kwarg to `open_channel_from()`
+            },
+
+            # lock around current actor task access
+            key=tractor.current_actor().uid,
+
+        ) as (cache_hit, (clients, chan)),
+    ):
+        if cache_hit:
+            log.error(
+                'Re-using cached `.open_from_channel()` call!\n'
+            )
+
+        else:
+            log.info(
+                'Allocating SHOULD-FAIL `.open_from_channel()`\n'
+            )
+
+        await trio.sleep_forever()
+
+
+# TODO, simulates connection-err from `piker.brokers.ib.api`..
+def test_aio_side_raises_before_started(
+    reg_addr: tuple[str, int],
+    debug_mode: bool,
+    loglevel: str,
+):
+    # delay = 999 if debug_mode else 1
+    async def main():
+        with trio.fail_after(3):
+            an: tractor.ActorNursery
+            async with tractor.open_nursery(
+                debug_mode=debug_mode,
+                loglevel=loglevel,
+            ) as an:
+                p: tractor.Portal = await an.start_actor(
+                    'lchan_cacher_that_raises_fast',
+                    enable_modules=[__name__],
+                    infect_asyncio=True,
+                )
+                async with p.open_context(
+                    caching_ep,
+                ) as (ctx, first):
+                    assert not first
+
+    with pytest.raises(
+        expected_exception=(RemoteActorError),
+    ) as excinfo:
+        trio.run(main)
+
+    # ensure `asyncio.Task` exception is bubbled
+    # allll the way erp!!
+    rae = excinfo.value
+    assert rae.boxed_type is RuntimeError
 
 # TODO: debug_mode tests once we get support for `asyncio`!
 #


### PR DESCRIPTION
Shocker, another `piker.brokerd.ib` discovered bug after updating to
py3.13 (and new `trio`).

Turns out any exc being raised prior to the first `.started()`-like
`to_trio.send_nowait()` call were not being propagated to the top of
the call stack (only `log.exception()` output if you scrolled up the
console hist..) making it confusing to grok where
a `.open_channel_from()` task crashed.

Instead this ensures that if the `to_trio: trio.abc.SendChannel`
closes (gracefully), thus raising a `trio.EndOfChannel` on the
`trio`-side, we check for an aio-side exc and ensure it's propagated
via `translate_aio_errors()`.

---

#### Summary of patch

- 4a7491b test-driven-dev suite to catch the *exc raised pre-`chan.send_nowait()`* case
  which should fail without a matching fix
- bd14830 actual fix for ^ by ensuring errors raised by any
  `.to_asyncio.open_channel_from()` spawned child-`asyncio.Task` are
  relayed by any caught `trio.EndOfChannel` by checking for a new
  `LinkedTaskChannel._closed_by_aio_task: bool` which should be set
  in such cases.
- 961504b adds a `LinkedTaskChannel.started_nowait()` for use in `.open_channel_from()` targets
  which declare a `chan` arg.
- b74e93e updates a single test (so we have at least one to verify) to the new ^ `chan` API.
