### PR TITLE
Add `start_or_cancel()` to `trionics._taskc`

### DIFF
--- a/tractor/trionics/__init__.py
+++ b/tractor/trionics/__init__.py
@@ -36,4 +36,5 @@ from ._beg import (
 )
 from ._taskc import (
     maybe_raise_from_masking_exc as maybe_raise_from_masking_exc,
+    start_or_cancel as start_or_cancel,
 )

--- a/tractor/trionics/_taskc.py
+++ b/tractor/trionics/_taskc.py
@@ -27,6 +27,9 @@ from types import (
     TracebackType,
 )
 from typing import (
+    Any,
+    Awaitable,
+    Callable,
     Type,
     TYPE_CHECKING,
 )
@@ -292,6 +295,56 @@ async def maybe_raise_from_masking_exc(
 
             if raise_unmasked:
                 raise exc_ctx from exc_match
+
+
+async def start_or_cancel(
+    nursery: trio.Nursery,
+    async_fn: Callable[..., Awaitable[Any]],
+    *args,
+    name: object = None,
+
+) -> Any:
+    '''
+    Like `trio.Nursery.start()` but DON'T mask an out-of-band
+    cancellation as a (lossy) startup failure.
+
+    `trio.Nursery.start()` raises a generic
+    `RuntimeError("child exited without calling
+    task_status.started()")` whenever the started task exits
+    BEFORE calling `task_status.started()` — INCLUDING the very
+    common case where the child was cancelled out-of-band by an
+    *ancestor* cancel-scope erroring/cancelling. In that case the
+    original `trio.Cancelled` is swallowed and the caller is left
+    with an opaque, root-cause-detached `RuntimeError`.
+
+    This wrapper re-surfaces any ambient (effective, hence
+    ancestor-inclusive) cancellation via
+    `trio.lowlevel.checkpoint_if_cancelled()` so the real
+    `trio.Cancelled` (carrying trio's auto-generated reason which
+    points at the true root exc) propagates instead. Only when we
+    are NOT under cancellation is the "didn't call `.started()`"
+    `RuntimeError` a genuine startup-protocol bug worth surfacing,
+    so it's re-raised as-is in that case.
+
+    '''
+    try:
+        return await nursery.start(
+            async_fn,
+            *args,
+            name=name,
+        )
+    except RuntimeError as rte:
+        if (
+            rte.args
+            and
+            'started' in rte.args[0]
+        ):
+            # re-raises the in-flight `trio.Cancelled` IFF we're
+            # under effective cancellation; else a cheap no-op and
+            # we fall through to re-raise the genuine startup RTE.
+            await trio.lowlevel.checkpoint_if_cancelled()
+
+        raise
 
     else:
         raise

--- a/tractor/trionics/_taskc.py
+++ b/tractor/trionics/_taskc.py
@@ -296,6 +296,9 @@ async def maybe_raise_from_masking_exc(
             if raise_unmasked:
                 raise exc_ctx from exc_match
 
+    else:
+        raise
+
 
 async def start_or_cancel(
     nursery: trio.Nursery,
@@ -344,7 +347,4 @@ async def start_or_cancel(
             # we fall through to re-raise the genuine startup RTE.
             await trio.lowlevel.checkpoint_if_cancelled()
 
-        raise
-
-    else:
         raise

--- a/tractor/trionics/_taskc.py
+++ b/tractor/trionics/_taskc.py
@@ -340,7 +340,16 @@ async def start_or_cancel(
         if (
             rte.args
             and
-            'started' in rte.args[0]
+            isinstance(rte.args[0], str)
+            and
+            # match trio's *exact* "child exited without calling
+            # task_status.started()" wording — a bare `'started'`
+            # substring would also match a child task's OWN
+            # `RuntimeError(...started...)` and (under cancellation)
+            # demote it to a `Cancelled`, losing the real error. The
+            # `isinstance` guard also avoids a `TypeError` when
+            # `rte.args[0]` isn't a `str`.
+            'child exited without calling' in rte.args[0]
         ):
             # re-raises the in-flight `trio.Cancelled` IFF we're
             # under effective cancellation; else a cheap no-op and


### PR DESCRIPTION
<!-- pr-msg-meta
branch: trionics_start_or_cancel
base: main
submitted:
  github: 464
  gitea: ___
  srht: ___
-->

## Add `start_or_cancel()` to `trionics._taskc`

### Motivation

`trio.Nursery.start()` collapses an out-of-band cancellation into a
lossy startup error. When the started task exits *before* calling
`task_status.started()` — including the very common case where it was
cancelled out-of-band by an *ancestor* cancel-scope erroring or
cancelling — trio raises a generic `RuntimeError("child exited
without calling task_status.started()")` and the original
`trio.Cancelled` is swallowed. The caller is left holding an opaque,
root-cause-detached `RuntimeError` instead of the real cancellation
(whose trio-generated reason points at the true root exc).

### Summary of changes

- Add `start_or_cancel()` — a `trio.Nursery.start()` wrapper that, on
  the "didn't call `.started()`" `RuntimeError`, re-surfaces any
  ambient (effective, hence ancestor-inclusive) cancellation via
  `trio.lowlevel.checkpoint_if_cancelled()` so the real
  `trio.Cancelled` propagates. Only when *not* under cancellation is
  that `RuntimeError` a genuine startup-protocol bug, so it's
  re-raised as-is. Exported from `tractor.trionics`.
- Fix a dropped `for/else` re-raise in `maybe_raise_from_masking_exc`
  (the masking CM) — the trailing `else: raise` belongs to the loop's
  `else` clause and had been mis-attached.

### TODOs before landing

- [ ] Stacked PR (base `main`) — this is the bottom of the remaining
  stack and lands first; `trio_033_upgrade` → `custom_log_levels_api`
  → `mtf_backend` stack above it.

<!--
### Cross-references
Also submitted as
[github-pr][] | [gitea-pr][] | [srht-patch][].
-->

### Links

- [#457][457] — per-actor `setproctitle` (closed; rode along the
  stack, drop before landing)

(this pr content was generated in some part by [`claude-code`][claude-code-gh])

[claude-code-gh]: https://github.com/anthropics/claude-code
[457]: https://github.com/goodboy/tractor/issues/457

<!-- cross-service pr refs (fill after submit):
[github-pr]: https://github.com/goodboy/tractor/pull/464
[gitea-pr]: https://pikers.dev/goodboy/tractor/pulls/___
[srht-patch]: https://git.sr.ht/~goodboy/tractor/patches/___
-->
