### PR TITLE
Restore Windows support (optional UDS + `SIGUSR1`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
     name: '${{ matrix.os }} Python${{ matrix.python-version }} spawn_backend=${{ matrix.spawn_backend }} tpt_proto=${{ matrix.tpt_proto }}'
     timeout-minutes: 16
     runs-on: ${{ matrix.os }}
+    # Windows support is nascent: keep its legs informational so a
+    # known-incomplete area doesn't block merges. The `import
+    # tractor` smoke step below is the hard signal for this job;
+    # promote the whole leg to required once the suite is green.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
     strategy:
       fail-fast: false
@@ -98,6 +103,7 @@ jobs:
         os: [
           ubuntu-latest,
           macos-latest,
+          windows-latest,
         ]
         python-version: [
           '3.13',
@@ -122,6 +128,10 @@ jobs:
         exclude:
           # don't do UDS run on macOS (for now)
           - os: macos-latest
+            tpt_proto: 'uds'
+          # UDS is POSIX-only; Windows has no `AF_UNIX` so the
+          # backend is intentionally unavailable there.
+          - os: windows-latest
             tpt_proto: 'uds'
 
     steps:
@@ -149,6 +159,12 @@ jobs:
 
       - name: List deps tree
         run: uv tree
+
+      # hard signal for the Windows import-safety fix: `import
+      # tractor` must succeed everywhere, and `HAS_UDS` reflects
+      # platform capability (False on Windows, True on POSIX).
+      - name: 'Smoke: import tractor'
+        run: uv run python -c "import tractor; from tractor.ipc._uds import HAS_UDS; print('import tractor OK | HAS_UDS=', HAS_UDS)"
 
       - name: Run tests
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,10 @@ jobs:
     name: '${{ matrix.os }} Python${{ matrix.python-version }} spawn_backend=${{ matrix.spawn_backend }} tpt_proto=${{ matrix.tpt_proto }}'
     timeout-minutes: 16
     runs-on: ${{ matrix.os }}
-    # Windows support is nascent: keep its legs informational so a
-    # known-incomplete area doesn't block merges. The `import
-    # tractor` smoke step below is the hard signal for this job;
-    # promote the whole leg to required once the suite is green.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    # Windows support is nascent: its full test suite remains
+    # informational, while setup and the `import tractor` smoke below
+    # are hard signals. Promote the test step to required once the
+    # suite is green.
 
     strategy:
       fail-fast: false
@@ -163,6 +162,7 @@ jobs:
         run: uv run python -c "import sys; import tractor; from tractor.ipc._uds import HAS_UDS; assert sys.platform != 'win32' or not HAS_UDS; print('import tractor OK | HAS_UDS=', HAS_UDS)"
 
       - name: Run tests
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}
         run: >
           uv run
           pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
     name: '${{ matrix.os }} Python${{ matrix.python-version }} spawn_backend=${{ matrix.spawn_backend }} tpt_proto=${{ matrix.tpt_proto }}'
     timeout-minutes: 16
     runs-on: ${{ matrix.os }}
+    # Windows support is nascent: keep its legs informational so a
+    # known-incomplete area doesn't block merges. The `import
+    # tractor` smoke step below is the hard signal for this job;
+    # promote the whole leg to required once the suite is green.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
     strategy:
       fail-fast: false
@@ -98,6 +103,7 @@ jobs:
         os: [
           ubuntu-latest,
           macos-latest,
+          windows-latest,
         ]
         python-version: [
           '3.13',
@@ -118,6 +124,11 @@ jobs:
           'tcp',
           'uds',
         ]
+        exclude:
+          # UDS is POSIX-only; Windows has no `AF_UNIX` so the
+          # backend is intentionally unavailable there.
+          - os: windows-latest
+            tpt_proto: 'uds'
 
     steps:
       - uses: actions/checkout@v4
@@ -144,6 +155,12 @@ jobs:
 
       - name: List deps tree
         run: uv tree
+
+      # hard signal for the Windows import-safety fix: `import
+      # tractor` must succeed everywhere, and `HAS_UDS` reflects
+      # platform capability (False on Windows, True on POSIX).
+      - name: 'Smoke: import tractor'
+        run: uv run python -c "import tractor; from tractor.ipc._uds import HAS_UDS; print('import tractor OK | HAS_UDS=', HAS_UDS)"
 
       - name: Run tests
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       # tractor` must succeed everywhere, and `HAS_UDS` reflects
       # platform capability (False on Windows, True on POSIX).
       - name: 'Smoke: import tractor'
-        run: uv run python -c "import tractor; from tractor.ipc._uds import HAS_UDS; print('import tractor OK | HAS_UDS=', HAS_UDS)"
+        run: uv run python -c "import sys; import tractor; from tractor.ipc._uds import HAS_UDS; assert sys.platform != 'win32' or not HAS_UDS; print('import tractor OK | HAS_UDS=', HAS_UDS)"
 
       - name: Run tests
         run: >

--- a/ai/prompt-io/opencode/20260817T231825Z_359fe75c_prompt_io.md
+++ b/ai/prompt-io/opencode/20260817T231825Z_359fe75c_prompt_io.md
@@ -1,0 +1,39 @@
+---
+model: openai/gpt-5.6-sol
+service: opencode
+session: pr475-review-fixes-20260817
+timestamp: 2026-08-17T23:18:25Z
+git_ref: 359fe75c
+scope: code
+substantive: true
+raw_file: 20260817T231825Z_359fe75c_prompt_io.raw.md
+---
+
+## Prompt
+
+Continue the `/code-review-changes` pass for PR #475 in its isolated
+worktree. Address the seven accepted manual-review findings in
+`tractor/ipc/_types.py` and `tractor/ipc/_uds.py`, preserve the existing
+Windows capability behavior, verify the result, and prepare the work for
+human-controlled commit and review-reply steps. Do not publish replies,
+stage, commit, or push without the required explicit authorization.
+
+## Response summary
+
+Restored project quote, docstring, multiline-expression, and
+`match/case` conventions while retaining the Windows-safe UDS guard.
+Removed unnecessary structural and comment churn, then verified the
+focused transport, discovery, and lazy-import paths plus the missing
+`AF_UNIX` behavior.
+
+## Files changed
+
+- `tractor/ipc/_types.py` - restore project style and guarded
+  socket-family dispatch.
+- `tractor/ipc/_uds.py` - format the UDS capability gate
+  consistently.
+
+## Human edits
+
+None - the generated patch remains uncommitted and awaits human
+review.

--- a/ai/prompt-io/opencode/20260817T231825Z_359fe75c_prompt_io.raw.md
+++ b/ai/prompt-io/opencode/20260817T231825Z_359fe75c_prompt_io.raw.md
@@ -1,0 +1,45 @@
+---
+model: openai/gpt-5.6-sol
+service: opencode
+timestamp: 2026-08-17T23:18:25Z
+git_ref: 359fe75c
+diff_cmd: git diff HEAD~1..HEAD
+---
+
+Applied the seven accepted manual-review fixes for PR #475 while
+preserving the Windows transport capability behavior.
+
+> `git diff HEAD~1..HEAD -- tractor/ipc/_types.py`
+
+The generated changes restore the project's single-quote docstring and
+string conventions, remove the unnecessary helper divider, simplify the
+transport-registry comments, and restore `match/case` socket-family
+dispatch. The UDS case retains a `HAS_UDS` guard that short-circuits
+before `socket.AF_UNIX` is evaluated on unsupported hosts. Nearby error
+messages are wrapped without changing their content.
+
+> `git diff HEAD~1..HEAD -- tractor/ipc/_uds.py`
+
+The generated change reformats the `HAS_UDS` conjunction according to
+the project's multiline boolean-expression convention and simplifies
+the adjacent capability comment.
+
+Verification:
+
+`/home/goodboy/repos/tractor/py313/bin/pytest -q tests/test_lazy_imports.py tests/discovery tests/ipc/test_server.py`
+
+Result: `66 passed, 2 xpassed in 60.62s`.
+
+`ruff check --no-cache --output-format=json tractor/ipc/_types.py tractor/ipc/_uds.py`
+
+Result: no findings.
+
+`git diff --check`
+
+Result: no whitespace errors.
+
+An explicit missing-`AF_UNIX` probe set `HAS_UDS = False`, removed the
+socket constant, and exercised an unsupported socket family. It raised
+the expected `NotImplementedError` instead of `AttributeError`.
+
+No review replies, commits, or pushes were published.

--- a/tests/test_infected_asyncio.py
+++ b/tests/test_infected_asyncio.py
@@ -20,6 +20,18 @@ from typing import (
 import pytest
 import trio
 import tractor
+
+# `infect_asyncio` mode is unsupported on Windows (asyncio's
+# `ProactorEventLoop` is incompatible with our `trio` guest-mode
+# interop and currently hangs/crashes the run). Skip the module on
+# Windows so the CI leg completes + reports the rest of the suite.
+import platform
+if platform.system() == 'Windows':
+    pytest.skip(
+        'infect_asyncio mode is unsupported on Windows',
+        allow_module_level=True,
+    )
+
 from tractor import (
     current_actor,
     Actor,

--- a/tests/test_ringbuf.py
+++ b/tests/test_ringbuf.py
@@ -1,9 +1,21 @@
 import time
+import platform
 
 import trio
 import pytest
 
 import tractor
+
+# `tractor.ipc._ringbuf` is built on linux `eventfd(2)`; importing
+# it pulls in `tractor.ipc._linux` whose module-level
+# `ffi.dlopen(None)` raises on non-linux. Skip the whole module at
+# COLLECTION before that crashing import runs (a `pytestmark` skip
+# is too late — markers apply only after the import succeeds).
+if platform.system() != 'Linux':
+    pytest.skip(
+        'ringbuf (eventfd) IPC is linux-only',
+        allow_module_level=True,
+    )
 
 # XXX `cffi` dun build on py3.14 yet..
 pytest.importorskip("cffi")

--- a/tests/test_root_infect_asyncio.py
+++ b/tests/test_root_infect_asyncio.py
@@ -9,6 +9,17 @@ from functools import partial
 import pytest
 import trio
 import tractor
+
+# `infect_asyncio` mode is unsupported on Windows (see
+# `test_infected_asyncio`); skip at COLLECTION before the
+# asyncio-interop imports below so the CI leg completes.
+import platform
+if platform.system() == 'Windows':
+    pytest.skip(
+        'infect_asyncio mode is unsupported on Windows',
+        allow_module_level=True,
+    )
+
 from tractor import (
     to_asyncio,
 )

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -73,6 +73,11 @@ async def test_lifetime_stack_wipes_tmpfile(
         1.6 if error_in_child
         else 1
     )
+    # scale for slow/noisy CI (esp. macOS) so the child error
+    # propagates before the deadline; otherwise `move_on_after`
+    # cancels first and flips the `error_in_child=True` assert.
+    from .conftest import cpu_perf_headroom
+    timeout *= cpu_perf_headroom()
     try:
         with trio.move_on_after(timeout) as cs:
             async with tractor.open_nursery(

--- a/tests/test_shm.py
+++ b/tests/test_shm.py
@@ -120,6 +120,13 @@ async def child_read_shm_list(
                 print(f'(child): reading frame: {frame}')
 
 
+@pytest.mark.skipif(
+    platform.system() == 'Windows',
+    reason=(
+        'parent/child shm IPC deadlocks on Windows '
+        '(frame-size dependent hang); nascent — see #404'
+    ),
+)
 @pytest.mark.parametrize(
     'use_str',
     [False, True],

--- a/tractor/devx/_stackscope.py
+++ b/tractor/devx/_stackscope.py
@@ -356,8 +356,8 @@ def dump_tree_on_sig(
 
 
 def enable_stack_on_sig(
-    sig: int = SIGUSR1,
-) -> ModuleType:
+    sig: int|None = SIGUSR1,
+) -> ModuleType|None:
     '''
     Enable `stackscope` tracing on reception of a signal; by
     default this is SIGUSR1.
@@ -376,6 +376,16 @@ def enable_stack_on_sig(
     >> pkill --signal SIGUSR1 -f <part-of-cmd: str>
 
     '''
+    # no `SIGUSR1` on this platform (e.g. Windows) -> nothing to
+    # wire up; degrade gracefully instead of crashing callers that
+    # only guard against a missing `stackscope` (`ImportError`).
+    if sig is None:
+        log.warning(
+            'No `SIGUSR1` on this platform;\n'
+            'skipping `stackscope` trace-on-signal setup!\n'
+        )
+        return None
+
     try:
         # NOTE, `stackscope._glue` does intentional async-gen type
         # introspection at import-time which trips

--- a/tractor/devx/_stackscope.py
+++ b/tractor/devx/_stackscope.py
@@ -31,12 +31,21 @@ from threading import (
     RLock,
 )
 import multiprocessing as mp
+
+import platform
+
 from signal import (
     signal,
     getsignal,
-    SIGUSR1,
     SIGINT,
 )
+
+
+if platform.system() != "Windows":
+    from signal import SIGUSR1
+else:
+    SIGUSR1 = None
+
 # import traceback
 from types import ModuleType
 from typing import (

--- a/tractor/discovery/_addr.py
+++ b/tractor/discovery/_addr.py
@@ -22,6 +22,10 @@ from typing import (
     TYPE_CHECKING,
 )
 
+import platform
+import socket
+
+
 from bidict import bidict
 from trio import (
     SocketListener,
@@ -32,13 +36,26 @@ from ..runtime._state import (
     _def_tpt_proto,
 )
 from ..ipc._tcp import TCPAddress
-from ..ipc._uds import UDSAddress
 
 if TYPE_CHECKING:
     from ..runtime._runtime import Actor
 
 log = get_logger()
 
+
+HAS_AF_UNIX = getattr(socket, "AF_UNIX", None) is not None
+IS_WINDOWS = platform.system() == "Windows"
+
+UDSAddress = None       # so references exist but do nothing on Windows
+
+if HAS_AF_UNIX and not IS_WINDOWS:
+    try:
+        from ..ipc._uds import UDSAddress as _UDSAddress
+        UDSAddress = _UDSAddress
+    except Exception as e:
+        log.warning("UDS backend import failed: %s", e)
+else:
+    log.warning("UDS backend disabled on this platform.")
 
 # TODO, maybe breakout the netns key to a struct?
 # class NetNs(Struct)[str, int]:
@@ -172,19 +189,24 @@ class Address(Protocol):
 
 _address_types: bidict[str, Type[Address]] = {
     'tcp': TCPAddress,
-    'uds': UDSAddress
 }
+
+if UDSAddress is not None:
+    _address_types['uds'] = UDSAddress
+else:
+    log.warning("Skipping UDS address type: no UDS backend available.")
 
 
 # TODO! really these are discovery sys default addrs ONLY useful for
 # when none is provided to a root actor on first boot.
-_default_lo_addrs: dict[
-    str,
-    UnwrappedAddress
-] = {
+_default_lo_addrs: dict[str, UnwrappedAddress] = {
     'tcp': TCPAddress.get_root().unwrap(),
-    'uds': UDSAddress.get_root().unwrap(),
 }
+
+if UDSAddress is not None:
+    _default_lo_addrs['uds'] = UDSAddress.get_root().unwrap()
+else:
+    log.warning("Skipping UDS default loopback address: no UDS backend available.")
 
 
 def get_address_cls(name: str) -> Type[Address]:

--- a/tractor/discovery/_addr.py
+++ b/tractor/discovery/_addr.py
@@ -172,24 +172,36 @@ class Address(Protocol):
         ...
 
 
-_address_types: bidict[str, Type[Address]] = {
-    'tcp': TCPAddress,
-}
+# the address types available on this host: TCP always, UDS only
+# where usable (`HAS_UDS`). Both registries derive from this single
+# list via each type's `proto_key`.
+_address_protos: list[Type[Address]] = [TCPAddress]
 if HAS_UDS:
-    _address_types['uds'] = UDSAddress
+    _address_protos.append(UDSAddress)
+
+_address_types: bidict[str, Type[Address]] = bidict({
+    cls.proto_key: cls
+    for cls in _address_protos
+})
 
 
 # TODO! really these are discovery sys default addrs ONLY useful for
 # when none is provided to a root actor on first boot.
 _default_lo_addrs: dict[str, UnwrappedAddress] = {
-    'tcp': TCPAddress.get_root().unwrap(),
+    cls.proto_key: cls.get_root().unwrap()
+    for cls in _address_protos
 }
-if HAS_UDS:
-    _default_lo_addrs['uds'] = UDSAddress.get_root().unwrap()
 
 
 def get_address_cls(name: str) -> Type[Address]:
-    return _address_types[name]
+    try:
+        return _address_types[name]
+    except KeyError:
+        raise NotImplementedError(
+            f'No IPC transport backend for {name!r} on this '
+            f'platform!\n'
+            f'(available: {list(_address_types)})\n'
+        )
 
 
 def is_wrapped_addr(addr: any) -> bool:
@@ -287,7 +299,14 @@ def default_lo_addrs(
     for an input transport key set.
 
     '''
-    return [
-        _default_lo_addrs[transport]
-        for transport in transports
-    ]
+    lo_addrs: list[UnwrappedAddress] = []
+    for transport in transports:
+        try:
+            lo_addrs.append(_default_lo_addrs[transport])
+        except KeyError:
+            raise NotImplementedError(
+                f'No default loopback addr for transport '
+                f'{transport!r} on this platform!\n'
+                f'(available: {list(_default_lo_addrs)})\n'
+            )
+    return lo_addrs

--- a/tractor/discovery/_addr.py
+++ b/tractor/discovery/_addr.py
@@ -22,10 +22,6 @@ from typing import (
     TYPE_CHECKING,
 )
 
-import platform
-import socket
-
-
 from bidict import bidict
 from trio import (
     SocketListener,
@@ -36,26 +32,15 @@ from ..runtime._state import (
     _def_tpt_proto,
 )
 from ..ipc._tcp import TCPAddress
+from ..ipc._uds import (
+    UDSAddress,
+    HAS_UDS,
+)
 
 if TYPE_CHECKING:
     from ..runtime._runtime import Actor
 
 log = get_logger()
-
-
-HAS_AF_UNIX = getattr(socket, "AF_UNIX", None) is not None
-IS_WINDOWS = platform.system() == "Windows"
-
-UDSAddress = None       # so references exist but do nothing on Windows
-
-if HAS_AF_UNIX and not IS_WINDOWS:
-    try:
-        from ..ipc._uds import UDSAddress as _UDSAddress
-        UDSAddress = _UDSAddress
-    except Exception as e:
-        log.warning("UDS backend import failed: %s", e)
-else:
-    log.warning("UDS backend disabled on this platform.")
 
 # TODO, maybe breakout the netns key to a struct?
 # class NetNs(Struct)[str, int]:
@@ -190,11 +175,8 @@ class Address(Protocol):
 _address_types: bidict[str, Type[Address]] = {
     'tcp': TCPAddress,
 }
-
-if UDSAddress is not None:
+if HAS_UDS:
     _address_types['uds'] = UDSAddress
-else:
-    log.warning("Skipping UDS address type: no UDS backend available.")
 
 
 # TODO! really these are discovery sys default addrs ONLY useful for
@@ -202,11 +184,8 @@ else:
 _default_lo_addrs: dict[str, UnwrappedAddress] = {
     'tcp': TCPAddress.get_root().unwrap(),
 }
-
-if UDSAddress is not None:
+if HAS_UDS:
     _default_lo_addrs['uds'] = UDSAddress.get_root().unwrap()
-else:
-    log.warning("Skipping UDS default loopback address: no UDS backend available.")
 
 
 def get_address_cls(name: str) -> Type[Address]:

--- a/tractor/discovery/_addr.py
+++ b/tractor/discovery/_addr.py
@@ -23,8 +23,6 @@ from typing import (
     TYPE_CHECKING,
 )
 
-import platform
-import socket
 from trio import (
     SocketListener,
 )
@@ -34,6 +32,10 @@ from ..runtime._state import (
     _def_tpt_proto,
 )
 from ..ipc._tcp import TCPAddress
+from ..ipc._uds import (
+    UDSAddress,
+    HAS_UDS,
+)
 
 if TYPE_CHECKING:
     # ONLY type-annots, the eager import costs ~4.5ms
@@ -43,21 +45,6 @@ else:
     Actor = Any
 
 log = get_logger()
-
-
-HAS_AF_UNIX = getattr(socket, "AF_UNIX", None) is not None
-IS_WINDOWS = platform.system() == "Windows"
-
-UDSAddress = None       # so references exist but do nothing on Windows
-
-if HAS_AF_UNIX and not IS_WINDOWS:
-    try:
-        from ..ipc._uds import UDSAddress as _UDSAddress
-        UDSAddress = _UDSAddress
-    except Exception as e:
-        log.warning("UDS backend import failed: %s", e)
-else:
-    log.warning("UDS backend disabled on this platform.")
 
 # TODO, maybe breakout the netns key to a struct?
 # class NetNs(Struct)[str, int]:
@@ -192,11 +179,8 @@ class Address(Protocol):
 _address_types: dict[str, Type[Address]] = {
     'tcp': TCPAddress,
 }
-
-if UDSAddress is not None:
+if HAS_UDS:
     _address_types['uds'] = UDSAddress
-else:
-    log.warning("Skipping UDS address type: no UDS backend available.")
 
 
 # TODO! really these are discovery sys default addrs ONLY useful for
@@ -204,11 +188,8 @@ else:
 _default_lo_addrs: dict[str, UnwrappedAddress] = {
     'tcp': TCPAddress.get_root().unwrap(),
 }
-
-if UDSAddress is not None:
+if HAS_UDS:
     _default_lo_addrs['uds'] = UDSAddress.get_root().unwrap()
-else:
-    log.warning("Skipping UDS default loopback address: no UDS backend available.")
 
 
 def get_address_cls(name: str) -> Type[Address]:

--- a/tractor/discovery/_addr.py
+++ b/tractor/discovery/_addr.py
@@ -176,24 +176,36 @@ class Address(Protocol):
         ...
 
 
-_address_types: dict[str, Type[Address]] = {
-    'tcp': TCPAddress,
-}
+# the address types available on this host: TCP always, UDS only
+# where usable (`HAS_UDS`). Both registries derive from this single
+# list via each type's `proto_key`.
+_address_protos: list[Type[Address]] = [TCPAddress]
 if HAS_UDS:
-    _address_types['uds'] = UDSAddress
+    _address_protos.append(UDSAddress)
+
+_address_types: dict[str, Type[Address]] = {
+    cls.proto_key: cls
+    for cls in _address_protos
+}
 
 
 # TODO! really these are discovery sys default addrs ONLY useful for
 # when none is provided to a root actor on first boot.
 _default_lo_addrs: dict[str, UnwrappedAddress] = {
-    'tcp': TCPAddress.get_root().unwrap(),
+    cls.proto_key: cls.get_root().unwrap()
+    for cls in _address_protos
 }
-if HAS_UDS:
-    _default_lo_addrs['uds'] = UDSAddress.get_root().unwrap()
 
 
 def get_address_cls(name: str) -> Type[Address]:
-    return _address_types[name]
+    try:
+        return _address_types[name]
+    except KeyError:
+        raise NotImplementedError(
+            f'No IPC transport backend for {name!r} on this '
+            f'platform!\n'
+            f'(available: {list(_address_types)})\n'
+        )
 
 
 def is_wrapped_addr(addr: any) -> bool:
@@ -291,7 +303,14 @@ def default_lo_addrs(
     for an input transport key set.
 
     '''
-    return [
-        _default_lo_addrs[transport]
-        for transport in transports
-    ]
+    lo_addrs: list[UnwrappedAddress] = []
+    for transport in transports:
+        try:
+            lo_addrs.append(_default_lo_addrs[transport])
+        except KeyError:
+            raise NotImplementedError(
+                f'No default loopback addr for transport '
+                f'{transport!r} on this platform!\n'
+                f'(available: {list(_default_lo_addrs)})\n'
+            )
+    return lo_addrs

--- a/tractor/discovery/_addr.py
+++ b/tractor/discovery/_addr.py
@@ -23,6 +23,8 @@ from typing import (
     TYPE_CHECKING,
 )
 
+import platform
+import socket
 from trio import (
     SocketListener,
 )
@@ -32,7 +34,6 @@ from ..runtime._state import (
     _def_tpt_proto,
 )
 from ..ipc._tcp import TCPAddress
-from ..ipc._uds import UDSAddress
 
 if TYPE_CHECKING:
     # ONLY type-annots, the eager import costs ~4.5ms
@@ -43,6 +44,20 @@ else:
 
 log = get_logger()
 
+
+HAS_AF_UNIX = getattr(socket, "AF_UNIX", None) is not None
+IS_WINDOWS = platform.system() == "Windows"
+
+UDSAddress = None       # so references exist but do nothing on Windows
+
+if HAS_AF_UNIX and not IS_WINDOWS:
+    try:
+        from ..ipc._uds import UDSAddress as _UDSAddress
+        UDSAddress = _UDSAddress
+    except Exception as e:
+        log.warning("UDS backend import failed: %s", e)
+else:
+    log.warning("UDS backend disabled on this platform.")
 
 # TODO, maybe breakout the netns key to a struct?
 # class NetNs(Struct)[str, int]:
@@ -176,19 +191,24 @@ class Address(Protocol):
 
 _address_types: dict[str, Type[Address]] = {
     'tcp': TCPAddress,
-    'uds': UDSAddress
 }
+
+if UDSAddress is not None:
+    _address_types['uds'] = UDSAddress
+else:
+    log.warning("Skipping UDS address type: no UDS backend available.")
 
 
 # TODO! really these are discovery sys default addrs ONLY useful for
 # when none is provided to a root actor on first boot.
-_default_lo_addrs: dict[
-    str,
-    UnwrappedAddress
-] = {
+_default_lo_addrs: dict[str, UnwrappedAddress] = {
     'tcp': TCPAddress.get_root().unwrap(),
-    'uds': UDSAddress.get_root().unwrap(),
 }
+
+if UDSAddress is not None:
+    _default_lo_addrs['uds'] = UDSAddress.get_root().unwrap()
+else:
+    log.warning("Skipping UDS default loopback address: no UDS backend available.")
 
 
 def get_address_cls(name: str) -> Type[Address]:

--- a/tractor/ipc/_server.py
+++ b/tractor/ipc/_server.py
@@ -27,6 +27,8 @@ from functools import partial
 from itertools import chain
 import inspect
 import textwrap
+import platform
+import socket
 from types import (
     ModuleType,
 )
@@ -62,16 +64,23 @@ from .. import log
 from ..discovery._addr import Address
 from ._chan import Channel
 from ._transport import MsgTransport
-from ._uds import UDSAddress
-from ._tcp import TCPAddress
+
 
 if TYPE_CHECKING:
     from ..runtime._runtime import Actor
     from ..runtime._supervise import ActorNursery
 
 
+from ._tcp import TCPAddress
+
 log = log.get_logger()
 
+UDSAddress = None
+
+if getattr(socket, "AF_UNIX", None) is not None and platform.system() != "Windows":
+    from ._uds import UDSAddress
+else:
+    pass
 
 async def maybe_wait_on_canced_subs(
     uid: tuple[str, str],

--- a/tractor/ipc/_server.py
+++ b/tractor/ipc/_server.py
@@ -27,8 +27,6 @@ from functools import partial
 from itertools import chain
 import inspect
 import textwrap
-import platform
-import socket
 from types import (
     ModuleType,
 )
@@ -72,15 +70,9 @@ if TYPE_CHECKING:
 
 
 from ._tcp import TCPAddress
+from ._uds import UDSAddress
 
 log = log.get_logger()
-
-UDSAddress = None
-
-if getattr(socket, "AF_UNIX", None) is not None and platform.system() != "Windows":
-    from ._uds import UDSAddress
-else:
-    pass
 
 async def maybe_wait_on_canced_subs(
     uid: tuple[str, str],

--- a/tractor/ipc/_server.py
+++ b/tractor/ipc/_server.py
@@ -27,6 +27,8 @@ from functools import partial
 from itertools import chain
 import inspect
 import textwrap
+import platform
+import socket
 from types import (
     ModuleType,
 )
@@ -62,18 +64,26 @@ from .. import log
 from ..discovery._addr import Address
 from ._chan import Channel
 from ._transport import MsgTransport
-from ._uds import UDSAddress
-from ._tcp import TCPAddress
+
 
 if TYPE_CHECKING:
     from ..runtime._runtime import Actor
     from ..runtime._supervise import ActorNursery
 
 
+from ._tcp import TCPAddress
+
 log = log.get_logger()
 
 _PRE_REG_HANDSHAKE_TIMEOUT: float = 10
 
+UDSAddress = None
+
+if (
+    getattr(socket, 'AF_UNIX', None) is not None
+    and platform.system() != 'Windows'
+):
+    from ._uds import UDSAddress
 
 async def maybe_wait_on_canced_subs(
     uid: tuple[str, str],

--- a/tractor/ipc/_server.py
+++ b/tractor/ipc/_server.py
@@ -27,8 +27,6 @@ from functools import partial
 from itertools import chain
 import inspect
 import textwrap
-import platform
-import socket
 from types import (
     ModuleType,
 )
@@ -72,18 +70,11 @@ if TYPE_CHECKING:
 
 
 from ._tcp import TCPAddress
+from ._uds import UDSAddress
 
 log = log.get_logger()
 
 _PRE_REG_HANDSHAKE_TIMEOUT: float = 10
-
-UDSAddress = None
-
-if (
-    getattr(socket, 'AF_UNIX', None) is not None
-    and platform.system() != 'Windows'
-):
-    from ._uds import UDSAddress
 
 async def maybe_wait_on_canced_subs(
     uid: tuple[str, str],

--- a/tractor/ipc/_types.py
+++ b/tractor/ipc/_types.py
@@ -18,106 +18,132 @@
 IPC subsys type-lookup helpers?
 
 '''
-from typing import (
-    Type,
-    # TYPE_CHECKING,
-)
-
-import trio
+from typing import Type
+import platform
 import socket
+import trio
 
+from tractor.log import get_logger
 from tractor.ipc._transport import (
     MsgTransportKey,
-    MsgTransport
+    MsgTransport,
 )
 from tractor.ipc._tcp import (
     TCPAddress,
     MsgpackTCPStream,
 )
-from tractor.ipc._uds import (
-    UDSAddress,
-    MsgpackUDSStream,
-)
 
-# if TYPE_CHECKING:
-#     from tractor._addr import Address
+log = get_logger()
 
+# ------------------------------------------------------------
+# Optional UDS backend (Windows / some Pythons may not have AF_UNIX)
+# ------------------------------------------------------------
+HAS_AF_UNIX = getattr(socket, "AF_UNIX", None) is not None
+IS_WINDOWS = platform.system() == "Windows"
 
-Address = TCPAddress|UDSAddress
+HAS_UDS = False
+UDSAddress = None  # type: ignore
+MsgpackUDSStream = None  # type: ignore
 
-# manually updated list of all supported msg transport types
-_msg_transports = [
+if HAS_AF_UNIX and not IS_WINDOWS:
+    try:
+        from tractor.ipc._uds import (  # type: ignore
+            UDSAddress as _UDSAddress,
+            MsgpackUDSStream as _MsgpackUDSStream,
+        )
+        UDSAddress = _UDSAddress  # type: ignore
+        MsgpackUDSStream = _MsgpackUDSStream  # type: ignore
+        HAS_UDS = True
+    except Exception as e:
+        log.warning("UDS backend unavailable (%s); continuing without it.", e)
+else:
+    if not HAS_AF_UNIX:
+        log.warning("AF_UNIX not exposed by this Python; disabling UDS backend.")
+    elif IS_WINDOWS:
+        # Even if the Windows kernel supports AF_UNIX, CPython may not expose it,
+        # and this project currently targets POSIX for the UDS backend.
+        log.warning("Windows detected; disabling UDS backend.")
+
+# ------------------------------------------------------------
+# Public types and transport registries
+# ------------------------------------------------------------
+
+# Address is TCP-only unless UDS is available.
+if HAS_UDS:
+    Address = TCPAddress | UDSAddress  # type: ignore
+else:
+    Address = TCPAddress  # type: ignore
+
+# Manually updated list of all supported msg transport types
+_msg_transports: list[Type[MsgTransport]] = [
     MsgpackTCPStream,
-    MsgpackUDSStream
 ]
+if HAS_UDS:
+    _msg_transports.append(MsgpackUDSStream)  # type: ignore
 
-
-# convert a MsgTransportKey to the corresponding transport type
-_key_to_transport: dict[
-    MsgTransportKey,
-    Type[MsgTransport],
-] = {
-    ('msgpack', 'tcp'): MsgpackTCPStream,
-    ('msgpack', 'uds'): MsgpackUDSStream,
+# Map MsgTransportKey -> transport type
+_key_to_transport: dict[MsgTransportKey, Type[MsgTransport]] = {
+    ("msgpack", "tcp"): MsgpackTCPStream,
 }
+if HAS_UDS:
+    _key_to_transport[("msgpack", "uds")] = MsgpackUDSStream  # type: ignore
 
-# convert an Address wrapper to its corresponding transport type
-_addr_to_transport: dict[
-    Type[TCPAddress|UDSAddress],
-    Type[MsgTransport]
-] = {
+# Map Address wrapper -> transport type
+_addr_to_transport: dict[Type[Address], Type[MsgTransport]] = {  # type: ignore
     TCPAddress: MsgpackTCPStream,
-    UDSAddress: MsgpackUDSStream,
 }
+if HAS_UDS:
+    _addr_to_transport[UDSAddress] = MsgpackUDSStream  # type: ignore
 
 
+# ------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------
 def transport_from_addr(
     addr: Address,
-    codec_key: str = 'msgpack',
+    codec_key: str = "msgpack",
 ) -> Type[MsgTransport]:
-    '''
+    """
     Given a destination address and a desired codec, find the
     corresponding `MsgTransport` type.
-
-    '''
+    """
     try:
-        return _addr_to_transport[type(addr)]
-
+        return _addr_to_transport[type(addr)]  # type: ignore[call-arg]
     except KeyError:
         raise NotImplementedError(
-            f'No known transport for address {repr(addr)}'
+            f"No known transport for address {repr(addr)}"
         )
 
 
 def transport_from_stream(
     stream: trio.abc.Stream,
-    codec_key: str = 'msgpack'
+    codec_key: str = "msgpack",
 ) -> Type[MsgTransport]:
-    '''
+    """
     Given an arbitrary `trio.abc.Stream` and a desired codec,
     find the corresponding `MsgTransport` type.
-
-    '''
+    """
     transport = None
+
     if isinstance(stream, trio.SocketStream):
         sock: socket.socket = stream.socket
-        match sock.family:
-            case socket.AF_INET | socket.AF_INET6:
-                transport = 'tcp'
+        fam = sock.family
 
-            case socket.AF_UNIX:
-                transport = 'uds'
+        if fam in (socket.AF_INET, getattr(socket, "AF_INET6", None)):
+            transport = "tcp"
 
-            case _:
-                raise NotImplementedError(
-                    f'Unsupported socket family: {sock.family}'
-                )
+        # Only consider AF_UNIX when both Python exposes it and our backend is active
+        if transport is None and HAS_UDS and HAS_AF_UNIX and fam == socket.AF_UNIX:  # type: ignore[attr-defined]
+            transport = "uds"
+
+        if transport is None:
+            raise NotImplementedError(f"Unsupported socket family: {fam}")
 
     if not transport:
         raise NotImplementedError(
-            f'Could not figure out transport type for stream type {type(stream)}'
+            f"Could not figure out transport type for stream type {type(stream)}"
         )
 
     key = (codec_key, transport)
-
     return _key_to_transport[key]
+

--- a/tractor/ipc/_types.py
+++ b/tractor/ipc/_types.py
@@ -41,26 +41,28 @@ from tractor.ipc._uds import (
 # hosts `HAS_UDS` is `False` and the runtime registers TCP only.
 Address = TCPAddress|UDSAddress
 
-# manually updated list of all supported msg transport types
+# the available msg-transport backends on this host: TCP always,
+# UDS only where usable (`HAS_UDS`). The lookup maps below are all
+# DERIVED from this single list via each backend's ClassVars
+# (`codec_key`, `address_type`) — register a backend here and every
+# map picks it up; no per-map `if HAS_UDS` to keep in sync.
 _msg_transports: list[Type[MsgTransport]] = [
     MsgpackTCPStream,
 ]
 if HAS_UDS:
     _msg_transports.append(MsgpackUDSStream)
 
-# map a `MsgTransportKey` to its `MsgTransport` type
+# map a `MsgTransportKey` -> `MsgTransport` type
 _key_to_transport: dict[MsgTransportKey, Type[MsgTransport]] = {
-    ('msgpack', 'tcp'): MsgpackTCPStream,
+    (t.codec_key, t.address_type.proto_key): t
+    for t in _msg_transports
 }
-if HAS_UDS:
-    _key_to_transport[('msgpack', 'uds')] = MsgpackUDSStream
 
-# map an `Address`-wrapper to its `MsgTransport` type
+# map an `Address`-wrapper -> `MsgTransport` type
 _addr_to_transport: dict[Type[Address], Type[MsgTransport]] = {
-    TCPAddress: MsgpackTCPStream,
+    t.address_type: t
+    for t in _msg_transports
 }
-if HAS_UDS:
-    _addr_to_transport[UDSAddress] = MsgpackUDSStream
 
 
 # ------------------------------------------------------------

--- a/tractor/ipc/_types.py
+++ b/tractor/ipc/_types.py
@@ -19,11 +19,9 @@ IPC subsys type-lookup helpers?
 
 '''
 from typing import Type
-import platform
 import socket
 import trio
 
-from tractor.log import get_logger
 from tractor.ipc._transport import (
     MsgTransportKey,
     MsgTransport,
@@ -32,68 +30,37 @@ from tractor.ipc._tcp import (
     TCPAddress,
     MsgpackTCPStream,
 )
+from tractor.ipc._uds import (
+    UDSAddress,
+    MsgpackUDSStream,
+    HAS_UDS,
+)
 
-log = get_logger()
+# the UDS backend is importable everywhere but only *usable* where
+# `trio` reports `has_unix` (i.e. POSIX). On Windows / no-`AF_UNIX`
+# hosts `HAS_UDS` is `False` and the runtime registers TCP only.
+Address = TCPAddress|UDSAddress
 
-# ------------------------------------------------------------
-# Optional UDS backend (Windows / some Pythons may not have AF_UNIX)
-# ------------------------------------------------------------
-HAS_AF_UNIX = getattr(socket, "AF_UNIX", None) is not None
-IS_WINDOWS = platform.system() == "Windows"
-
-HAS_UDS = False
-UDSAddress = None  # type: ignore
-MsgpackUDSStream = None  # type: ignore
-
-if HAS_AF_UNIX and not IS_WINDOWS:
-    try:
-        from tractor.ipc._uds import (  # type: ignore
-            UDSAddress as _UDSAddress,
-            MsgpackUDSStream as _MsgpackUDSStream,
-        )
-        UDSAddress = _UDSAddress  # type: ignore
-        MsgpackUDSStream = _MsgpackUDSStream  # type: ignore
-        HAS_UDS = True
-    except Exception as e:
-        log.warning("UDS backend unavailable (%s); continuing without it.", e)
-else:
-    if not HAS_AF_UNIX:
-        log.warning("AF_UNIX not exposed by this Python; disabling UDS backend.")
-    elif IS_WINDOWS:
-        # Even if the Windows kernel supports AF_UNIX, CPython may not expose it,
-        # and this project currently targets POSIX for the UDS backend.
-        log.warning("Windows detected; disabling UDS backend.")
-
-# ------------------------------------------------------------
-# Public types and transport registries
-# ------------------------------------------------------------
-
-# Address is TCP-only unless UDS is available.
-if HAS_UDS:
-    Address = TCPAddress | UDSAddress  # type: ignore
-else:
-    Address = TCPAddress  # type: ignore
-
-# Manually updated list of all supported msg transport types
+# manually updated list of all supported msg transport types
 _msg_transports: list[Type[MsgTransport]] = [
     MsgpackTCPStream,
 ]
 if HAS_UDS:
-    _msg_transports.append(MsgpackUDSStream)  # type: ignore
+    _msg_transports.append(MsgpackUDSStream)
 
-# Map MsgTransportKey -> transport type
+# map a `MsgTransportKey` to its `MsgTransport` type
 _key_to_transport: dict[MsgTransportKey, Type[MsgTransport]] = {
-    ("msgpack", "tcp"): MsgpackTCPStream,
+    ('msgpack', 'tcp'): MsgpackTCPStream,
 }
 if HAS_UDS:
-    _key_to_transport[("msgpack", "uds")] = MsgpackUDSStream  # type: ignore
+    _key_to_transport[('msgpack', 'uds')] = MsgpackUDSStream
 
-# Map Address wrapper -> transport type
-_addr_to_transport: dict[Type[Address], Type[MsgTransport]] = {  # type: ignore
+# map an `Address`-wrapper to its `MsgTransport` type
+_addr_to_transport: dict[Type[Address], Type[MsgTransport]] = {
     TCPAddress: MsgpackTCPStream,
 }
 if HAS_UDS:
-    _addr_to_transport[UDSAddress] = MsgpackUDSStream  # type: ignore
+    _addr_to_transport[UDSAddress] = MsgpackUDSStream
 
 
 # ------------------------------------------------------------
@@ -132,8 +99,10 @@ def transport_from_stream(
         if fam in (socket.AF_INET, getattr(socket, "AF_INET6", None)):
             transport = "tcp"
 
-        # Only consider AF_UNIX when both Python exposes it and our backend is active
-        if transport is None and HAS_UDS and HAS_AF_UNIX and fam == socket.AF_UNIX:  # type: ignore[attr-defined]
+        # only consider `AF_UNIX` when the UDS backend is active;
+        # `HAS_UDS` short-circuits before `socket.AF_UNIX` so this
+        # stays safe on hosts where that constant is absent.
+        if transport is None and HAS_UDS and fam == socket.AF_UNIX:  # type: ignore[attr-defined]
             transport = "uds"
 
         if transport is None:

--- a/tractor/ipc/_types.py
+++ b/tractor/ipc/_types.py
@@ -18,106 +18,131 @@
 IPC subsys type-lookup helpers?
 
 '''
-from typing import (
-    Type,
-    # TYPE_CHECKING,
-)
-
-import trio
+from typing import Type
+import platform
 import socket
+import trio
 
+from tractor.log import get_logger
 from tractor.ipc._transport import (
     MsgTransportKey,
-    MsgTransport
+    MsgTransport,
 )
 from tractor.ipc._tcp import (
     TCPAddress,
     MsgpackTCPStream,
 )
-from tractor.ipc._uds import (
-    UDSAddress,
-    MsgpackUDSStream,
-)
 
-# if TYPE_CHECKING:
-#     from tractor._addr import Address
+log = get_logger()
 
+# ------------------------------------------------------------
+# Optional UDS backend (Windows / some Pythons may not have AF_UNIX)
+# ------------------------------------------------------------
+HAS_AF_UNIX = getattr(socket, "AF_UNIX", None) is not None
+IS_WINDOWS = platform.system() == "Windows"
 
-Address = TCPAddress|UDSAddress
+HAS_UDS = False
+UDSAddress = None  # type: ignore
+MsgpackUDSStream = None  # type: ignore
 
-# manually updated list of all supported msg transport types
-_msg_transports = [
+if HAS_AF_UNIX and not IS_WINDOWS:
+    try:
+        from tractor.ipc._uds import (  # type: ignore
+            UDSAddress as _UDSAddress,
+            MsgpackUDSStream as _MsgpackUDSStream,
+        )
+        UDSAddress = _UDSAddress  # type: ignore
+        MsgpackUDSStream = _MsgpackUDSStream  # type: ignore
+        HAS_UDS = True
+    except Exception as e:
+        log.warning("UDS backend unavailable (%s); continuing without it.", e)
+else:
+    if not HAS_AF_UNIX:
+        log.warning("AF_UNIX not exposed by this Python; disabling UDS backend.")
+    elif IS_WINDOWS:
+        # Even if the Windows kernel supports AF_UNIX, CPython may not expose it,
+        # and this project currently targets POSIX for the UDS backend.
+        log.warning("Windows detected; disabling UDS backend.")
+
+# ------------------------------------------------------------
+# Public types and transport registries
+# ------------------------------------------------------------
+
+# Address is TCP-only unless UDS is available.
+if HAS_UDS:
+    Address = TCPAddress | UDSAddress  # type: ignore
+else:
+    Address = TCPAddress  # type: ignore
+
+# Manually updated list of all supported msg transport types
+_msg_transports: list[Type[MsgTransport]] = [
     MsgpackTCPStream,
-    MsgpackUDSStream
 ]
+if HAS_UDS:
+    _msg_transports.append(MsgpackUDSStream)  # type: ignore
 
-
-# convert a MsgTransportKey to the corresponding transport type
-_key_to_transport: dict[
-    MsgTransportKey,
-    Type[MsgTransport],
-] = {
-    ('msgpack', 'tcp'): MsgpackTCPStream,
-    ('msgpack', 'uds'): MsgpackUDSStream,
+# Map MsgTransportKey -> transport type
+_key_to_transport: dict[MsgTransportKey, Type[MsgTransport]] = {
+    ("msgpack", "tcp"): MsgpackTCPStream,
 }
+if HAS_UDS:
+    _key_to_transport[("msgpack", "uds")] = MsgpackUDSStream  # type: ignore
 
-# convert an Address wrapper to its corresponding transport type
-_addr_to_transport: dict[
-    Type[TCPAddress|UDSAddress],
-    Type[MsgTransport]
-] = {
+# Map Address wrapper -> transport type
+_addr_to_transport: dict[Type[Address], Type[MsgTransport]] = {  # type: ignore
     TCPAddress: MsgpackTCPStream,
-    UDSAddress: MsgpackUDSStream,
 }
+if HAS_UDS:
+    _addr_to_transport[UDSAddress] = MsgpackUDSStream  # type: ignore
 
 
+# ------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------
 def transport_from_addr(
     addr: Address,
-    codec_key: str = 'msgpack',
+    codec_key: str = "msgpack",
 ) -> Type[MsgTransport]:
-    '''
+    """
     Given a destination address and a desired codec, find the
     corresponding `MsgTransport` type.
-
-    '''
+    """
     try:
-        return _addr_to_transport[type(addr)]
-
+        return _addr_to_transport[type(addr)]  # type: ignore[call-arg]
     except KeyError:
         raise NotImplementedError(
-            f'No known transport for address {repr(addr)}'
+            f"No known transport for address {repr(addr)}"
         )
 
 
 def transport_from_stream(
     stream: trio.abc.Stream,
-    codec_key: str = 'msgpack'
+    codec_key: str = "msgpack",
 ) -> Type[MsgTransport]:
-    '''
+    """
     Given an arbitrary `trio.abc.Stream` and a desired codec,
     find the corresponding `MsgTransport` type.
-
-    '''
+    """
     transport = None
+
     if isinstance(stream, trio.SocketStream):
         sock: socket.socket = stream.socket
-        match sock.family:
-            case socket.AF_INET | socket.AF_INET6:
-                transport = 'tcp'
+        fam = sock.family
 
-            case socket.AF_UNIX:
-                transport = 'uds'
+        if fam in (socket.AF_INET, getattr(socket, "AF_INET6", None)):
+            transport = "tcp"
 
-            case _:
-                raise NotImplementedError(
-                    f'Unsupported socket family: {sock.family}'
-                )
+        # Only consider AF_UNIX when both Python exposes it and our backend is active
+        if transport is None and HAS_UDS and HAS_AF_UNIX and fam == socket.AF_UNIX:  # type: ignore[attr-defined]
+            transport = "uds"
+
+        if transport is None:
+            raise NotImplementedError(f"Unsupported socket family: {fam}")
 
     if not transport:
         raise NotImplementedError(
-            f'Could not figure out transport type for stream type {type(stream)}'
+            f"Could not figure out transport type for stream type {type(stream)}"
         )
 
     key = (codec_key, transport)
-
     return _key_to_transport[key]

--- a/tractor/ipc/_types.py
+++ b/tractor/ipc/_types.py
@@ -36,16 +36,14 @@ from tractor.ipc._uds import (
     HAS_UDS,
 )
 
-# the UDS backend is importable everywhere but only *usable* where
-# `trio` reports `has_unix` (i.e. POSIX). On Windows / no-`AF_UNIX`
-# hosts `HAS_UDS` is `False` and the runtime registers TCP only.
+# the UDS backend is importable everywhere but only *usable* when
+# `HAS_UDS` is `True`; otherwise the runtime registers TCP only.
 Address = TCPAddress|UDSAddress
 
 # the available msg-transport backends on this host: TCP always,
-# UDS only where usable (`HAS_UDS`). The lookup maps below are all
-# DERIVED from this single list via each backend's ClassVars
-# (`codec_key`, `address_type`) — register a backend here and every
-# map picks it up; no per-map `if HAS_UDS` to keep in sync.
+# UDS only where usable (`HAS_UDS`). The lookup maps below derive
+# from this single list via each backend's `codec_key` and
+# `address_type`: register a backend here and every map picks it up.
 _msg_transports: list[Type[MsgTransport]] = [
     MsgpackTCPStream,
 ]
@@ -65,55 +63,63 @@ _addr_to_transport: dict[Type[Address], Type[MsgTransport]] = {
 }
 
 
-# ------------------------------------------------------------
-# Helpers
-# ------------------------------------------------------------
 def transport_from_addr(
     addr: Address,
-    codec_key: str = "msgpack",
+    codec_key: str = 'msgpack',
 ) -> Type[MsgTransport]:
-    """
+    '''
     Given a destination address and a desired codec, find the
     corresponding `MsgTransport` type.
-    """
+
+    '''
     try:
-        return _addr_to_transport[type(addr)]  # type: ignore[call-arg]
+        addr_type = type(addr)
+        return _addr_to_transport[addr_type]
+
     except KeyError:
         raise NotImplementedError(
-            f"No known transport for address {repr(addr)}"
+            f'No known transport for address '
+            f'{addr!r}'
         )
 
 
 def transport_from_stream(
     stream: trio.abc.Stream,
-    codec_key: str = "msgpack",
+    codec_key: str = 'msgpack',
 ) -> Type[MsgTransport]:
-    """
+    '''
     Given an arbitrary `trio.abc.Stream` and a desired codec,
     find the corresponding `MsgTransport` type.
-    """
-    transport = None
+
+    '''
+    transport: str|None = None
 
     if isinstance(stream, trio.SocketStream):
         sock: socket.socket = stream.socket
-        fam = sock.family
+        match sock.family:
+            case socket.AF_INET | socket.AF_INET6:
+                transport = 'tcp'
 
-        if fam in (socket.AF_INET, getattr(socket, "AF_INET6", None)):
-            transport = "tcp"
+            # `HAS_UDS` short-circuits before `socket.AF_UNIX` on
+            # hosts where that constant is absent.
+            case fam if (
+                HAS_UDS
+                and
+                fam == socket.AF_UNIX
+            ):
+                transport = 'uds'
 
-        # only consider `AF_UNIX` when the UDS backend is active;
-        # `HAS_UDS` short-circuits before `socket.AF_UNIX` so this
-        # stays safe on hosts where that constant is absent.
-        if transport is None and HAS_UDS and fam == socket.AF_UNIX:  # type: ignore[attr-defined]
-            transport = "uds"
-
-        if transport is None:
-            raise NotImplementedError(f"Unsupported socket family: {fam}")
+            case fam:
+                raise NotImplementedError(
+                    f'Unsupported socket family: {fam}'
+                )
 
     if not transport:
         raise NotImplementedError(
-            f"Could not figure out transport type for stream type {type(stream)}"
+            f'Could not figure out transport type for stream type '
+            f'{type(stream)}'
         )
 
     key = (codec_key, transport)
+
     return _key_to_transport[key]

--- a/tractor/ipc/_uds.py
+++ b/tractor/ipc/_uds.py
@@ -25,11 +25,21 @@ from pathlib import Path
 import os
 import sys
 from socket import (
-    AF_UNIX,
     SOCK_STREAM,
     SOL_SOCKET,
     error as socket_error,
 )
+# NOTE, `AF_UNIX` is absent on Windows / any CPython built without
+# unix-domain-socket support. Keep this module importable
+# everywhere (so `UDSAddress` stays referenceable for type and
+# `isinstance()` checks plus registry lookups); the `AF_UNIX`-using
+# code paths below are runtime-only and are never reached when the
+# UDS backend is unusable (gated on `trio`'s `has_unix`, see
+# `HAS_UDS`).
+try:
+    from socket import AF_UNIX
+except ImportError:
+    AF_UNIX = None
 import struct
 from typing import (
     Type,
@@ -89,6 +99,13 @@ else:
 
 
 log = get_logger()
+
+
+# single source of truth for "is the UDS backend usable on this
+# host?" — reuse `trio`'s `has_unix` (the same predicate that gates
+# `trio.open_unix_socket()`) rather than re-deriving an `AF_UNIX`
+# probe in every consumer module.
+HAS_UDS: bool = has_unix
 
 
 def unwrap_sockpath(

--- a/tractor/ipc/_uds.py
+++ b/tractor/ipc/_uds.py
@@ -115,10 +115,12 @@ _SUN_PATH_LIMIT: int = (
 
 
 # single source of truth for "is the UDS backend usable on this
-# host?" — reuse `trio`'s `has_unix` (the same predicate that gates
-# `trio.open_unix_socket()`) rather than re-deriving an `AF_UNIX`
-# probe in every consumer module.
-HAS_UDS: bool = has_unix
+# host?" Windows can expose `AF_UNIX`, but this backend remains
+# POSIX-only until its credential and lifecycle paths are supported.
+HAS_UDS: bool = (
+    sys.platform != 'win32'
+    and has_unix
+)
 
 
 def unwrap_sockpath(

--- a/tractor/ipc/_uds.py
+++ b/tractor/ipc/_uds.py
@@ -114,12 +114,13 @@ _SUN_PATH_LIMIT: int = (
 )
 
 
-# single source of truth for "is the UDS backend usable on this
-# host?" Windows can expose `AF_UNIX`, but this backend remains
+# single source of truth for whether the UDS backend is usable on this
+# host. Windows can expose `AF_UNIX`, but this backend remains
 # POSIX-only until its credential and lifecycle paths are supported.
 HAS_UDS: bool = (
     sys.platform != 'win32'
-    and has_unix
+    and
+    has_unix
 )
 
 

--- a/tractor/ipc/_uds.py
+++ b/tractor/ipc/_uds.py
@@ -26,11 +26,21 @@ from pathlib import Path
 import os
 import sys
 from socket import (
-    AF_UNIX,
     SOCK_STREAM,
     SOL_SOCKET,
     error as socket_error,
 )
+# NOTE, `AF_UNIX` is absent on Windows / any CPython built without
+# unix-domain-socket support. Keep this module importable
+# everywhere (so `UDSAddress` stays referenceable for type and
+# `isinstance()` checks plus registry lookups); the `AF_UNIX`-using
+# code paths below are runtime-only and are never reached when the
+# UDS backend is unusable (gated on `trio`'s `has_unix`, see
+# `HAS_UDS`).
+try:
+    from socket import AF_UNIX
+except ImportError:
+    AF_UNIX = None
 import struct
 from typing import (
     Any,
@@ -102,6 +112,13 @@ _SUN_PATH_LIMIT: int = (
     if sys.platform == 'linux'
     else 104
 )
+
+
+# single source of truth for "is the UDS backend usable on this
+# host?" — reuse `trio`'s `has_unix` (the same predicate that gates
+# `trio.open_unix_socket()`) rather than re-deriving an `AF_UNIX`
+# probe in every consumer module.
+HAS_UDS: bool = has_unix
 
 
 def unwrap_sockpath(


### PR DESCRIPTION
<!-- pr-msg-meta
branch: windows_support_round2
base: main
head_oid: 93322405a10c09c30cf899db8ce9379e0f6c0f71
base_tip_oid: 8f0df0ff6f5208271cf74fb696a95e26d7a90e39
merge_base_oid: 8f0df0ff6f5208271cf74fb696a95e26d7a90e39
provider_diff_base_oid: unavailable
commit_range: 8f0df0ff6f5208271cf74fb696a95e26d7a90e39..93322405a10c09c30cf899db8ce9379e0f6c0f71
diff_range: 8f0df0ff6f5208271cf74fb696a95e26d7a90e39...93322405a10c09c30cf899db8ce9379e0f6c0f71
authority: forge-verified
submitted:
  github: 475
-->

## Restore Windows support (optional UDS + `SIGUSR1`)

Replacement for #408, towards #404 and #405.

---

### Motivation

Before this branch, `import tractor` raised on Windows and on CPython
builds without `socket.AF_UNIX`. The UDS transport backend imported
`AF_UNIX` at module load, while `tractor.devx._stackscope` imported
`signal.SIGUSR1`; either name can be unavailable on Windows. Several
core modules pull `_uds` into the package import graph, so this
blocked all downstream Windows use.

This makes the UDS backend and `SIGUSR1` trace-dump hook optional.
The runtime now degrades to TCP-only operation without `SIGUSR1`
instead of failing during import. Native Windows UDS use remains out
of scope until its credential and lifecycle paths are supported.

---

### Summary of changes

- Keep `tractor.ipc._uds` importable everywhere by narrowly handling
  a missing `socket.AF_UNIX`; `UDSAddress` remains a concrete type
  while runtime UDS use stays capability-gated.

- Define `HAS_UDS` as false on Windows and wherever Trio reports no
  Unix socket support. Derive transport and address registries from
  the active backend list so TCP remains available without stray UDS
  entries.

- Make `signal.SIGUSR1` optional in
  `tractor.devx._stackscope.enable_stack_on_sig()`, which now
  degrades gracefully when the signal is unavailable.

- Add Windows-specific collection skips and timing allowances for
  tests that depend on POSIX signals, shared-memory IPC, or
  unsupported `infect_asyncio` behavior.

- Add a Windows TCP CI leg. Dependency setup, `import tractor`, and
  the `HAS_UDS` smoke assertion remain hard failures; only the
  Windows `pytest` step is temporarily non-blocking while #476 tracks
  suite cleanup.

---

### Testing on Windows

Hands-on community testing is welcome. Run these steps in PowerShell:

1. Install Python 3.13 from https://www.python.org/downloads/ and
   select "Add python.exe to PATH" in the installer.

2. Install `uv`:

   ```powershell
   pip install uv
   ```

3. Clone the repository and check out this PR:

   ```powershell
   gh repo clone goodboy/tractor
   cd tractor
   gh pr checkout 475
   ```

4. Create the virtual environment and install dependencies:

   ```powershell
   uv sync
   ```

5. Run the import and capability smoke check. It must print
   `ok False`:

   ```powershell
   uv run python -c "import tractor; from tractor.ipc._uds import HAS_UDS; print('ok', HAS_UDS)"
   ```

6. Run the test suite over TCP:

   ```powershell
   uv run pytest tests/ --tpt-proto tcp -rsx
   ```

Please report the smoke-test output, final `pytest` summary, and full
tracebacks for any failures on #476.

---

### Future follow up

The clean transport-unavailable error and data-driven transport
registries are included here. The remaining Windows-suite cleanup and
promotion of the Windows `pytest` step to a hard gate are tracked in
[#476][followup]. Native Windows UDS support remains tracked in [#405][windows-uds].

---

### Links

- towards #404 (multi-platform support umbrella)
- towards #405 (native Windows UDS support)
- replaces #408
- follow-up suite cleanup: #476

<!--
### Cross-references
Also submitted as [github-pr][] | [gitea-pr][] | [srht-patch][].
-->

<!-- cross-service pr refs (fill after submit):
[github-pr]: https://github.com/goodboy/tractor/pull/475
[gitea-pr]: https://pikers.dev/goodboy/tractor/pulls/___
[srht-patch]: https://git.sr.ht/~goodboy/tractor/patches/___
-->

(this pr content was generated in some part by `opencode` using
`gpt-5.6-sol` (`openai`))

[followup]: https://github.com/goodboy/tractor/issues/476
[windows-uds]: https://github.com/goodboy/tractor/issues/405
