### PR TITLE
Retry macOS tests with `pytest-rerunfailures`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,10 @@ jobs:
         run: uv run python -c "import sys; import tractor; from tractor.ipc._uds import HAS_UDS; assert sys.platform != 'win32' or not HAS_UDS; print('import tractor OK | HAS_UDS=', HAS_UDS)"
 
       - name: Run tests
+        # Actor/PTY scheduling on macOS can fail a different
+        # timing-sensitive node between otherwise-green runs. Retry
+        # only that matrix leg; deterministic failures still fail
+        # after the final attempt.
         continue-on-error: ${{ matrix.os == 'windows-latest' }}
         run: >
           uv run
@@ -171,6 +175,8 @@ jobs:
           --spawn-backend=${{ matrix.spawn_backend }}
           --tpt-proto=${{ matrix.tpt_proto }}
           --capture=fd
+          --reruns=${{ matrix.os == 'macos-latest' && 2 || 0 }}
+          --reruns-delay=1
 
   # XXX legacy NOTE XXX
   #

--- a/ai/prompt-io/opencode/20260821T052052Z_3690e43a_prompt_io.md
+++ b/ai/prompt-io/opencode/20260821T052052Z_3690e43a_prompt_io.md
@@ -1,0 +1,37 @@
+---
+model: gpt-5.6-sol
+service: opencode
+session: tractor-addr-unpacking
+timestamp: 2026-08-21T05:20:52Z
+git_ref: 3690e43a
+scope: config
+substantive: true
+raw_file: 20260821T052052Z_3690e43a_prompt_io.raw.md
+---
+
+## Prompt
+
+The human asked for a main-first patch using an off-the-shelf pytest
+plugin to cope with tractor's changing macOS CI flakes without mixing
+that mitigation into PR #505.
+
+## Response summary
+
+Added `pytest-rerunfailures` to tractor's testing dependencies and
+configured the GitHub Actions matrix to retry failures only on macOS.
+Linux and Windows remain strict first-attempt runs, while persistent
+macOS failures still fail after two visible reruns.
+
+## Files changed
+
+- `.github/workflows/ci.yml` - macOS-only pytest rerun budget.
+- `pyproject.toml` - testing plugin dependency and rationale.
+- `uv.lock` - resolved `pytest-rerunfailures` package metadata.
+
+## Human edits
+
+The human selected a main-first mitigation after PR #505 failed two
+different macOS tests on consecutive runs and required the change to
+remain an incremental patch with its own commit plan. The agent
+implemented and verified that direction; no direct manual source
+edits were observed.

--- a/ai/prompt-io/opencode/20260821T052052Z_3690e43a_prompt_io.raw.md
+++ b/ai/prompt-io/opencode/20260821T052052Z_3690e43a_prompt_io.raw.md
@@ -1,0 +1,25 @@
+---
+model: gpt-5.6-sol
+service: opencode
+timestamp: 2026-08-21T05:20:52Z
+git_ref: 3690e43a
+diff_cmd: git diff HEAD~1..HEAD
+---
+
+# Raw output - retry flaky macOS CI tests
+
+The human requested an off-the-shelf pytest plugin patch suitable
+for landing directly on tractor `main` after PR #505's macOS job
+failed two different timing-sensitive tests on consecutive runs.
+
+> `git diff HEAD~1..HEAD -- .github/workflows/ci.yml pyproject.toml uv.lock`
+
+Added the pytest-dev-maintained `pytest-rerunfailures` plugin and
+gave only the macOS matrix leg two reruns with a one-second delay.
+Linux and Windows receive a zero retry budget; deterministic macOS
+failures still fail after the final attempt and reruns remain visible
+in pytest output.
+
+The lockfile is current, actionlint passed, all 471 tests collected,
+and the four tests covering both observed PR #505 failure areas
+passed with the rerun plugin enabled.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ testing = [
   # cleanup utility (xplatform `Process.memory_maps`,
   # `Process.open_files`).
   "psutil>=7.0.0",
+  # rerun timing-sensitive macOS CI nodes without hiding a
+  # deterministic failure after the final attempt.
+  "pytest-rerunfailures>=16.6,<17",
 ]
 repl = [
   "pyperclip>=1.9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -783,6 +783,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "16.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/63/0114e45d4b2fcd5f6297dac655c067b47de28be4d33e088f200f0f2c4c28/pytest_rerunfailures-16.6.tar.gz", hash = "sha256:29dbfee46f542073c888e0ed4e81c51e15b9096f49a299eb1a759629c601684a", size = 42806, upload-time = "2026-08-17T07:11:00.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5e/1e994889673d7a0da11651f17ef789b6c83bfe349f29f871873dd3802445/pytest_rerunfailures-16.6-py3-none-any.whl", hash = "sha256:6af2d1ebd6e5cb79666ac408942cd6a0672a49fefd8523664770718560795e13", size = 19137, upload-time = "2026-08-17T07:10:59.121Z" },
+]
+
+[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1131,6 +1144,7 @@ dev = [
     { name = "psutil" },
     { name = "pyperclip" },
     { name = "pytest" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "stackscope" },
     { name = "typing-extensions" },
@@ -1170,6 +1184,7 @@ testing = [
     { name = "pexpect" },
     { name = "psutil" },
     { name = "pytest" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
 ]
 
@@ -1195,6 +1210,7 @@ dev = [
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-rerunfailures", specifier = ">=16.6,<17" },
     { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "stackscope", specifier = ">=0.2.2,<0.3" },
     { name = "typing-extensions", specifier = ">=4.14.1" },
@@ -1226,6 +1242,7 @@ testing = [
     { name = "pexpect", specifier = ">=4.9.0,<5" },
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-rerunfailures", specifier = ">=16.6,<17" },
     { name = "pytest-timeout", specifier = ">=2.3" },
 ]
 


### PR DESCRIPTION
Give only the macOS matrix leg two retries so actor/PTY timing flakes do not strand otherwise-green runs. Linux and Windows receive no retries; Windows remains informational under its pre-existing `continue-on-error` policy. Persistent macOS failures stay red after the final visible rerun.

Details,
- add the pytest-dev-maintained plugin to testing deps
- keep a one-second delay between macOS attempts
- validate the workflow, lock and both observed flaky test areas

Prompt-IO: ai/prompt-io/opencode/20260821T052052Z_3690e43a_prompt_io.md

(this patch was generated in some part by `opencode` using `gpt-5.6-sol` (`openai`))
